### PR TITLE
REPLY-X_Update response top level members

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Just remember, when creating an `Error Response` (Multi or Single), the passed m
 // See how we have to reply.ErrorManifests, on with mulitple
 // items and the other with just one.
 baseManifest := []reply.ErrorManifest{
-		{
-			"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound},
-			"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"},
-		},
-		{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
-	}
+    {
+      "example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound},
+      "example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"},
+    },
+    {"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
+  }
 
 // Create Replier to manage the responses going back to consumer(s)
 replier := reply.NewReplier(baseManifest)
@@ -175,11 +175,12 @@ func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
 
   // Pass error to Replier's method to return predefined response, else
-	// 500
-	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-		Writer: w,
-		Error:  exampleErr,
-	})
+  // 500
+  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+    Writer: w,
+    Error:  exampleErr,
+  })
+}
 ```
 
 When the endpoint linked to the handler above is called, you should see the following JSON response.
@@ -214,24 +215,24 @@ Below you will find an example using `NewHTTPResponse`, however for simplicity, 
 func ExampleGetAllHandler(w http.ResponseWriter, r *http.Request) {
 
   // building sample user model
-	type user struct {
-		ID   int    `json:"id"`
-		Name string `json:"name"`
-	}
+  type user struct {
+    ID   int    `json:"id"`
+    Name string `json:"name"`
+  }
 
-	// emulate users pulled from repository
-	mockedQueriedUsers := []user{
-		{ID: 1, Name: "John Doe"},
-		{ID: 2, Name: "Sam Smith"},
-	}
+  // emulate users pulled from repository
+  mockedQueriedUsers := []user{
+    {ID: 1, Name: "John Doe"},
+    {ID: 2, Name: "Sam Smith"},
+  }
 
-	// build and sent default formatted JSON response for consumption
-	// by client
-	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-		Writer:     w,
-		Data:       mockedUsers,
-		StatusCode: htttp.StatusOK,
-	})
+  // build and sent default formatted JSON response for consumption
+  // by client
+  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+    Writer:     w,
+    Data:       mockedUsers,
+    StatusCode: htttp.StatusOK,
+  })
 }
 ```
 
@@ -414,16 +415,16 @@ If you wanted to send a `multi error response`, you could use the following, ass
 ```go
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-	// errors returned
-	exampleErrs := []errors{
-		errors.New("example-name-validation-error"),
-		errors.New("example-dob-validation-error"),
-	}
+  // errors returned
+  exampleErrs := []errors{
+    errors.New("example-name-validation-error"),
+    errors.New("example-dob-validation-error"),
+  }
 
-	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-		Writer: w,
-		Errors: exampleErrs,
-	})
+  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+    Writer: w,
+    Errors: exampleErrs,
+  })
 }
 
 ```
@@ -448,16 +449,16 @@ You can also add additional `headers` and `meta data` to the response by using t
 
 ```go
 _ = replier.NewHTTPErrorResponse(w, exampleErr, reply.WithMeta(map[string]interface{}{
-		"example": "meta in error reponse",
-	}))
+    "example": "meta in error reponse",
+  }))
 ```
 
 **OR**
 
 ```go
 _ = replier.NewHTTPMultiErrorResponse(w, exampleErrs, reply.WithMeta(map[string]interface{}{
-		"example": "meta in error reponse",
-	}))
+    "example": "meta in error reponse",
+  }))
 ```
 
 #### JSON Representation
@@ -557,14 +558,14 @@ replier := reply.NewReplier([]reply.ErrorManifest{})
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-	// do something to get tokens
+  // do something to get tokens
 
-	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-		Writer:     w,
-		TokenOne:   "08a0a043-b532-4cea-8117-364739f2d994",
-		TokenTwo:   "08b29914-09a8-4a4a-8aa5-b1ffaff266e6",
-		StatusCode: 200,
-	})
+  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+    Writer:     w,
+    TokenOne:   "08a0a043-b532-4cea-8117-364739f2d994",
+    TokenTwo:   "08b29914-09a8-4a4a-8aa5-b1ffaff266e6",
+    StatusCode: 200,
+  })
 }
 ```
 
@@ -632,17 +633,17 @@ replier := reply.NewReplier([]reply.ErrorManifest{})
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-	u := user{
-		id:   1,
-		name: "john doe",
-		dob:  "1/1/1970",
-	}
+  u := user{
+    id:   1,
+    name: "john doe",
+    dob:  "1/1/1970",
+  }
 
-	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-		Writer:     w,
-		Data:       u,
-		StatusCode: 201,
-	})
+  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+    Writer:     w,
+    Data:       u,
+    StatusCode: 201,
+  })
 }
 ```
 
@@ -658,8 +659,8 @@ You can also add additional `headers` and `meta data` to the response by using t
 
 ```go
 _ = replier.NewHTTPDataResponse(w, 201, u, reply.WithMeta(map[string]interface{}{
-		"example": "meta in data reponse",
-	}))
+    "example": "meta in data reponse",
+  }))
 ```
 
 #### JSON Representation
@@ -706,10 +707,10 @@ replier := reply.NewReplier([]reply.ErrorManifest{})
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-		Writer:     w,
-		StatusCode: 200,
-	})
+  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+    Writer:     w,
+    StatusCode: 200,
+  })
 }
 ```
 
@@ -724,8 +725,8 @@ You can also add additional `headers` and `meta data` to the response by using t
 
 ```go
 _ = replier.NewHTTPBlankResponse(w, 200, reply.WithMeta(map[string]interface{}{
-		"example": "meta in default reponse",
-	}))
+    "example": "meta in default reponse",
+  }))
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ type TransferObject interface {
 	SetHeaders(headers map[string]string)
 	SetStatusCode(code int)
 	SetMeta(meta map[string]interface{})
-	SetAccessToken(token string)
-	SetRefreshToken(token string)
+	SetTokenOne(token string)
+	SetTokenTwo(token string)
 	GetWriter() http.ResponseWriter
 	GetStatusCode() int
 	SetWriter(writer http.ResponseWriter)

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ func ExampleGetAllHandler(w http.ResponseWriter, r *http.Request) {
 		Data:       mockedUsers,
 		StatusCode: htttp.StatusOK,
 	})
+}
 ```
 
 When the endpoint linked to the handler above is called, you should see the following JSON response.
@@ -306,7 +307,7 @@ replier := reply.NewReplier([]reply.ErrorManifest{}, reply.WithTransferObject(cu
 
 > For a live example on how you can use a custom `transfer object`, please look at the [`simple API examples` in this repo](./examples/example_simple_api.go). You are looking out for the `fooReplyTransferObject` implementation.
 
-### Eroor Transfer Object (`TransferObjectError`)
+### Error Transfer Object (`TransferObjectError`)
 
 The `Transfer Object` used for the `individual error response object` **must** satisfy the following interface:
 
@@ -413,7 +414,7 @@ If you wanted to send a `multi error response`, you could use the following, ass
 ```go
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-  // errors returned
+	// errors returned
 	exampleErrs := []errors{
 		errors.New("example-name-validation-error"),
 		errors.New("example-dob-validation-error"),
@@ -436,7 +437,7 @@ For readability and simplicity, you can use the `HTTP error response aides`. You
 _ = replier.NewHTTPErrorResponse(w, exampleErr)
 ```
 
-- `Multiple Errors`
+- `Multi Error`
 
 ```go
 // inside of the request handler
@@ -476,7 +477,7 @@ _ = replier.NewHTTPMultiErrorResponse(w, exampleErrs, reply.WithMeta(map[string]
 }
 ```
 
-- `Multiple Errors`
+- `Multi Error`
 
 ```json
 {
@@ -517,7 +518,7 @@ When a `meta` is also declared, the response will have the following format. It 
 }
 ```
 
-- `Multiple Errors`
+- `Multi Error`
 
 ```json
 {
@@ -556,7 +557,7 @@ replier := reply.NewReplier([]reply.ErrorManifest{})
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-  // do something to get tokens
+	// do something to get tokens
 
 	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
 		Writer:     w,
@@ -631,7 +632,7 @@ replier := reply.NewReplier([]reply.ErrorManifest{})
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-  u := user{
+	u := user{
 		id:   1,
 		name: "john doe",
 		dob:  "1/1/1970",
@@ -705,7 +706,7 @@ replier := reply.NewReplier([]reply.ErrorManifest{})
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
 		Writer:     w,
 		StatusCode: 200,
 	})

--- a/README.md
+++ b/README.md
@@ -1,34 +1,38 @@
 # reply
 
-`reply` is a Go library that supports developers with shaping and standardising the responses sent from their API service(s). It also allows users to predefine non-successful messages and their corresponding status code based on the error manifest(s) passed to the `replier`.
+`reply` is a Go library that supports developers with shaping and standardising the responses sent from their API service(s). It also allows users to predefine non-successful error objects, giving a granularity down to `title`, `description`, `status code`, and many more through the error manifest(s) passed to the `Replier`.
 
 ## Table of Contents
 
 - [Installation](#installation)
-- [Examples](#examples)
-- [How to create a `replier`](#how-to-create-a-replier)
-- [How to send response(s)](#how-to-send-responses)
-    - [Making use of error manifest](#making-use-of-error-manifest)
-    - [Sending client successful response](#sending-client-successful-response)
+- [Getting Started](#getting-started)
+  - [How to create a `Replier`](#how-to-create-a-replier)
+  - [More about the `ErrorManifest`](#more-about-the-errormanifest)
+    - [Deeper look into `ErrorManifestItem`](#deeper-look-into-errormanifestitem)
+- [How to send a response(s)](#how-to-send-a-responses)
+  - [Making use of error manifest](#making-use-of-error-manifest)
+  - [Sending  "successful responses"](#sending--successful-responses)
 - [Transfer Objects](#transfer-objects)
+  - [Base Transfer Object (`TransferObject`)](#base-transfer-object-transferobject)
+  - [Eroor Transfer Object (`TransferObjectError`)](#eroor-transfer-object-transferobjecterror)
 - [Response Types](#response-types)
-- [Universal Attributes](#universal-attributes)
-- [Error Response Type](#error-response-type)
+  - [Universal Attributes](#universal-attributes)
+  - [Error Response Type](#error-response-type)
     - [As code (including aide example)](#as-code-including-aide-example)
     - [JSON Representation](#json-representation)
-    - [With `Meta`](#with-meta)
-- [Token Response Type](#token-response-type)
+      - [With `Meta`](#with-meta)
+  - [Token Response Type](#token-response-type)
     - [As code (including aide example)](#as-code-including-aide-example-1)
     - [JSON Representation](#json-representation-1)
-    - [With `Meta`](#with-meta-1)
-- [Data Response Type](#data-response-type)
+      - [With `Meta`](#with-meta-1)
+  - [Data Response Type](#data-response-type)
     - [As code (including aide example)](#as-code-including-aide-example-2)
     - [JSON Representation](#json-representation-2)
-    - [With `Meta`](#with-meta-2)
-- [Default (Blank) Response Type](#default-blank-response-type)
+      - [With `Meta`](#with-meta-2)
+  - [Default (Blank) Response Type](#default-blank-response-type)
     - [As code (including aide example)](#as-code-including-aide-example-3)
     - [JSON Representation](#json-representation-3)
-    - [With `Meta`](#with-meta-3)
+      - [With `Meta`](#with-meta-3)
 - [Copyright](#copyright)
 
 ---
@@ -37,33 +41,128 @@
 ## Installation
 
 ```sh
-go get github.com/ooaklee/reply
+  go get github.com/ooaklee/reply
 ```
 
-## Examples
+## Getting Started
 
 There are several ways you can integrate `reply` into your application. Below, you will find an example of how you can get the most out of this package.
 
-### How to create a `replier`
+### How to create a `Replier`
+
+When creating a `Replier`, you only have to pass a `reply.ErrorManifest` collection. The collection can be empty or contain as many entries as you'd like.
+
+Just remember, when creating an `Error Response` (Multi or Single), the passed manifest will be used.
 
 ```go
-// (Optional) Create a error manifest, to hold correlating error as string and it's manifest
+// (Optional) Create an error manifest to hold correlating errors as a string and their manifest
 // item
+//
+// See how we have to reply.ErrorManifests, on with mulitple
+// items and the other with just one.
 baseManifest := []reply.ErrorManifest{
-                {"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
-            }
+		{
+			"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound},
+			"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"},
+		},
+		{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
+	}
 
-// Create replier to manage the responses going back to consumer(s)
+// Create Replier to manage the responses going back to consumer(s)
 replier := reply.NewReplier(baseManifest)
 ```
 
-### How to send response(s) 
+> NOTE - By default, if an `Error Manifest Item` does not have a `StatusCode` set, `reply` will default to `400 (Bad Request)`.
 
-You can use `reply` for both successful and error based responses.
+### More about the `ErrorManifest` 
 
-> `NOTE` - When sending an error response, it is essential to make sure you populate the `replier`'s error manifest with the correct errors. Otherwise, a `500 - Internal Server Error` response will be sent back to the client by default if it cannot match the passed error in the manifest.
+The `ErrorManifest` contains a string key which is the string representation of an `error type` and its corresponding `ErrorManifestItem`.
 
-#### Making use of error manifest
+The `ErrorManifestItem` is used to explicitly define the attributes to include in your response's error object. Like previously mentioned, the string key is returned when `err.Error()` is run, assuming err was the standard `error type`.
+
+#### Deeper look into `ErrorManifestItem`
+
+`ErrorManifestItems` will come in various sizes depending on how much information you what to make visible to your consumer.
+
+> It is essential to evaluate the exposure level of your API continuously. Is it something that will be used external to your team/ business, and thus minimal information should be given?
+
+The key attributes of the `ErrorManifestItem` are:
+
+- **Title** (`string`): Summary of the error being returned. Try keeping it short and sweet.
+
+- **Detail** (`string`): Gives a more descriptive outline of the error, something with more context.
+ 
+- **StatusCode** (`int`): The [HTTP Status Code](https://httpstatuses.com) associated with respective error. If it's a `5XX` error, it will be the sole error object returned in a `multi error response` scenario.
+ 
+- **About** (`string`): The URL to a page that gives more context about the error
+
+- **Code** (`string`): The `internal code` (application or business) that's used to identify the error
+
+- **Meta** (`interface{}`): Any additional meta-information you may want to pass with your error object
+
+Assuming an `ErrorManifest` containing the following entry was passed to a `Replier`,
+
+```go
+{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}}
+``` 
+
+And its respective error was passed when creating a new error response (`NewHTTPErrorResponse`). `reply` would return the following JSON response:
+
+```json
+{
+  "errors": [
+    {
+      "title": "Validation Error",
+      "detail": "The name provided does not meet validation requirements",
+      "about": "www.example.com/reply/validation/1011",
+      "status": "400",
+      "code": "1011"
+    }
+  ]
+}
+```
+
+If instead, multiple errors were passed to the `NewHTTPMultiErrorResponse` method, and all had an entry in the `ErrorManifest`, `reply` would return a response similar to the following JSON response:
+
+
+```json
+{
+  "errors": [
+    {
+      "title": "Validation Error",
+      "detail": "The name provided does not meet validation requirements",
+      "about": "www.example.com/reply/validation/1011",
+      "status": "400",
+      "code": "1011"
+    },
+    {
+      "title": "Validation Error",
+      "detail": "The email provided does not meet validation requirements",
+      "status": "400"
+    }
+  ]
+}
+```
+
+> NOTE - Not all attributes in the `ErrorManifestItem` have to be specified. By default, if a `StatusCode` is not provided in the item `400` would be set. 
+
+> NOTE - You can create your own custom error json response shape, by using the `reply.WithTransferObjectError` option when creating your replier. Check the [**example simple api ** implementation (`replierWithCustomTransitionObjs`)](examples/example_simple_api.go) for a working example.
+
+## How to send a response(s) 
+
+At the core, you can use `reply` two send both successful and error responses.
+
+When sending an error response, it is essential to make sure you populate the `Error Manifest` passed to the `Replier` with the correct error key strings. Otherwise, a `500 - Internal Server Error` response will be sent back to the client by default if it cannot match the passed error in the manifest.
+
+Having expected `ErrorManifest` entries are especially important for `Multi Error` responses. One unmatched error will return a single `500 - Internal Server Error` instead of the array of passed error responses.
+
+### Making use of error manifest
+
+There are currently **3** Replier methods that make use of the `Error Manifest`. These methods are `NewHTTPResponse`, `NewHTTPMultiErrorResponse` and `NewHTTPErrorResponse`.
+
+> NOTE - `NewHTTPResponse` is the base of both the `NewHTTPMultiErrorResponse` and `NewHTTPErrorResponse` aides.
+
+Below you will find an example using `NewHTTPResponse`. However, for simplicity, it's recommended you use one of the error aides. The error [aide implementation is outlined **HERE**](#error-response-type).
 
 ```go
 
@@ -71,37 +170,42 @@ You can use `reply` for both successful and error based responses.
 // response
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-    // Create error with value corresponding to one of the manifest's entry's key
-    exampleErr := errors.New("example-404-error")
+  // Create error with value corresponding to one of the manifest's entry's key
+  exampleErr := errors.New("example-404-error")
 
 
-    // Pass error to replier's method to return predefined response, else
-    // 500
-    _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-        Writer: w,
-        Error:  exampleErr,
-    })
-}
+  // Pass error to Replier's method to return predefined response, else
+	// 500
+	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+		Writer: w,
+		Error:  exampleErr,
+	})
 ```
 
 When the endpoint linked to the handler above is called, you should see the following JSON response.
 
-> `NOTE` - The `baseManifest` was initially declared, and its item represents the response shown below. Although the status code is not shown in the response body, it to has been set accordingly and returned to the consumer.
-
 ```JSON
-
 {
   "errors": [
     {
-      "title":  "resource not found",
+      "title": "resource not found",
       "status": "404"
     }
   ]
 }
 ```
 
-#### Sending client successful response
+> `NOTE` - The `baseManifest` was initially declared, and its item represents the response shown below. The status code is both shown in the response body as a string, and it is also set accordingly. 
 
+### Sending  "successful responses"
+
+The **3** Replier methods that can send "successful responses" are `NewHTTPResponse`, `NewHTTPBlankResponse` and `NewHTTPDataResponse`.
+
+> NOTE - `NewHTTPResponse` is the base of both the `NewHTTPBlankResponse` and `NewHTTPDataResponse` aides.
+
+Below you will find an example using `NewHTTPResponse`, however for simplicity, it's recommended you use either of the follow aide implementations:
+ - [Blank Response Aide](#default-blank-response-type)
+ - [Data Response Aide](#data-response-type) 
 
 ```go
 
@@ -109,68 +213,78 @@ When the endpoint linked to the handler above is called, you should see the foll
 // response
 func ExampleGetAllHandler(w http.ResponseWriter, r *http.Request) {
 
-    // building sample user model 
-    type user struct {
-        ID int `json:"id"`
-        Name string `json:"name"`
-    }
+  // building sample user model
+	type user struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
 
-    // emulate users pulled from repository
-    mockedQueriedUsers := []user{
-        {ID: 1, Name: "John Doe"},
-        {ID: 2, Name: "Sam Smith"},
-    }
+	// emulate users pulled from repository
+	mockedQueriedUsers := []user{
+		{ID: 1, Name: "John Doe"},
+		{ID: 2, Name: "Sam Smith"},
+	}
 
-
-    // build and sent default formatted JSON response for consumption
-    // by client 
-    _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-        Writer: w,
-        Data: mockedUsers
-        StatusCode: htttp.StatusOK
-    })
-}
+	// build and sent default formatted JSON response for consumption
+	// by client
+	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+		Writer:     w,
+		Data:       mockedUsers,
+		StatusCode: htttp.StatusOK,
+	})
 ```
 
 When the endpoint linked to the handler above is called, you should see the following JSON response.
 
-> `NOTE` - Unlike the error use case, successful requests expect the `StatusCode` to be defined when creating a successful response. If you do not provide a status code, 200 will be assumed.
-
 ```JSON
 {
-    "data": [
-        {"id": 1, "name": "John Doe"},
-        {"id": 2, "name": "Sam Smith"}
-    ]
+  "data": [
+    {
+      "id": 1,
+      "name": "John Doe"
+    },
+    {
+      "id": 2,
+      "name": "Sam Smith"
+    }
+  ]
 }
 ```
 
-### Transfer Objects
+> `NOTE` - Unlike the error use case, successful requests expect the `StatusCode` to be defined when creating a successful response. If you do not provide a status code, 200 will be assumed.
+> 
+> It is recommend to use use either the [Blank Response Aide](#default-blank-response-type) or [Data Response Aide](#data-response-type) based on your desired ouput
 
-### TODO: Update to include newly added `Transfer Object Error`
+## Transfer Objects
 
-A `Transfer object` defines the shape of the response. if desired, users can create their own `transfer object` with additional logic, but it must satisfy the following interface:
+`Transfer objects` are used to define the shape of various elements within the overall response. In particular, they are used for the `base response object` and the `individual error response object`.
+
+If desired, users can create their own `transfer object` for the `base` and `individual error` response objects with additional logic.
+
+### Base Transfer Object (`TransferObject`)
+
+The `Transfer Object` used for the `base response object` **must** satisfy the following interface:
 
 ```go
 // TransferObject outlines expected methods of a transfer object
 type TransferObject interface {
-	SetHeaders(headers map[string]string)
-	SetStatusCode(code int)
-	SetMeta(meta map[string]interface{})
-	SetTokenOne(token string)
-	SetTokenTwo(token string)
-	GetWriter() http.ResponseWriter
-	GetStatusCode() int
-	SetWriter(writer http.ResponseWriter)
-	SetStatus(transferObjectStatus *TransferObjectStatus)
-	RefreshTransferObject() TransferObject
-	SetData(data interface{})
+  SetHeaders(headers map[string]string)
+  SetStatusCode(code int)
+  SetMeta(meta map[string]interface{})
+  SetTokenOne(token string)
+  SetTokenTwo(token string)
+  GetWriter() http.ResponseWriter
+  GetStatusCode() int
+  SetWriter(writer http.ResponseWriter)
+  SetStatus(transferObjectStatus *TransferObjectStatus)
+  RefreshTransferObject() TransferObject
+  SetData(data interface{})
 }
 ```
 
 The interface uses relatively self-explanatory method names. Still, if you want to see an example of how one might create your own `transfer object`, you can find the `default transfer object` used by `reply` [here (defaultReplyTransferObject)](./model.go). 
 
-Once your `transfer object` has been created and is valid, you can overwrite the default `transfer object` in your newly created version by using the following code when declaring your `replier`:
+Once your `transfer object` has been created and is valid, you can overwrite the default `transfer object` in your newly created version by using the following code when declaring your `Replier`:
 
 ```go
 // some implementation of your desired transfer object
@@ -179,10 +293,10 @@ var customTransferObject reply.TransferObject
 customTransferObject = &foo{}
 
 
-// create a replier, overwriting the default transfer object
+// create a Replier, overwriting the default transfer object
 replier := reply.NewReplier([]reply.ErrorManifest{}, reply.WithTransferObject(customTransferObject))
 
-// use the new replier as you otherwise would
+// use the new Replier as you otherwise would
 ```
 
 > *NOTE:* you can also pass in your custom transfer object with `&foo{}`, for example:
@@ -190,14 +304,65 @@ replier := reply.NewReplier([]reply.ErrorManifest{}, reply.WithTransferObject(cu
 > `replier := reply.NewReplier([]reply.ErrorManifest{}, reply.WithTransferObject(&foo{}))`
 
 
-> For a live example on how you can use a custom `transfer object` please look at the [`simple api examples` in this repo](./examples/example_simple_api.go). You are looking out for the `fooReplyTransferObject` implementation.
+> For a live example on how you can use a custom `transfer object`, please look at the [`simple API examples` in this repo](./examples/example_simple_api.go). You are looking out for the `fooReplyTransferObject` implementation.
+
+### Eroor Transfer Object (`TransferObjectError`)
+
+The `Transfer Object` used for the `individual error response object` **must** satisfy the following interface:
+
+```go
+// TransferObjectError outlines expected methods of a transfer object error
+type TransferObjectError interface {
+  SetTitle(title string)
+  GetTitle() string
+  SetDetail(detail string)
+  GetDetail() string
+  SetAbout(about string)
+  GetAbout() string
+  SetStatusCode(status int)
+  GetStatusCode() string
+  SetCode(code string)
+  GetCode() string
+  SetMeta(meta interface{})
+  GetMeta() interface{}
+  RefreshTransferObject() TransferObjectError
+}
+```
+
+The interface uses relatively self-explanatory method names. Look at the [deeper dive of the Error Manifest Item](#deeper-look-into-errormanifestitem) to better understand how these methods are used. 
+
+Suppose you want to see an example of how one might create your own `transfer object error`. In that case, you can find the `default transfer object error` used by `reply` [here (defaultReplyTransferObjectError)](./model.go). 
+
+You can overwrite the default `transfer object error` used by your `Replier` by using the following code when declaring your `Replier`:
+
+```go
+// some implementation of your desired transfer object
+var customTransferObjectError reply.TransferObjectError
+
+customTransferObjectError = &bar{}
+
+
+// create a Replier, overwriting the default transfer object error (error transfer object)
+replier := reply.NewReplier([]reply.ErrorManifest{}, reply.WithTransferObjectError(customTransferObjectError))
+
+// use the new Replier as you otherwise would
+```
+
+> *NOTE:* you can also pass in your custom transfer object with `&bar{}`, for example:
+>
+> `replier := reply.NewReplier([]reply.ErrorManifest{}, reply.customTransferObjectError(&bar{}))`
+
+
+> For a live example on how you can use a custom `transfer object error` in combination with a custom `transfer object`, please look at the [`simple API examples` in this repo](./examples/example_simple_api.go). You are looking out for the `replierWithCustomTransitionObjs` implementation.
+>
+> You can set your custom `transfer object error` individually, as shown above.
 
 
 ## Response Types
 
-There are currently four core response types supported by `reply`. They are the `Error`, `Token`, `Data` (*Success*) and `Default` response types. Each type has its JSON representation which is defined through a `Transfer Object`.
+There are currently four core response types supported by `reply`. They are the `Error`, `Token`, `Data` and `Default` response types. Each type has its JSON representation defined through a [`Transfer Object`](#transfer-objects).
 
-> NOTE: Unless otherwise stated, the `Transfer Object` assumed will be the [default transfer object (defaultReplyTransferObject)](./model.go)
+> NOTE: Unless otherwise stated, the `Transfer Objects` assumed will be the [default transfer object (defaultReplyTransferObject)](./model.go) and [default transfer object error (defaultReplyTransferObjectError)](./model.go).
 
 ### Universal Attributes
 
@@ -206,61 +371,127 @@ All core response types share universal attributes, which you can set in additio
 - Meta
 - Status Code
 
+> NOTE - `Status Code` is set at different levels dependant on `response type`. For example, the `error response type` is handled in the [`ErrorManifest`](#more-about-the-errormanifest).
+
 ### Error Response Type
 
-The `Error` response notifies the consumer when an error/ unexpected behaviour has occurred on the API. The message and the status code forwarded to the consumer is sourced from the error manifest. In the event the error's string
+The `Error` response notifies the consumer when an error/ unexpected behaviour has occurred on the API. There are **2** types of `Error Response Types`, Individual (`NewHTTPErrorResponse`) and Multi (`NewHTTPMultiErrorResponse`).
+
+The error response object forwarded to the consumer is sourced from the [error manifest](#more-about-the-errormanifest). In the event the error's string
 representation isn't in the manifest; `reply` will return the consumer a "500 - Internal Server Error" response.
 
 #### As code (including aide example)
 
-To create an `error` response use the following code snippet:
+To create an individual `error` response use the following code snippet:
 
 ```go
 // create error manifest
 baseManifest := []reply.ErrorManifest{
-                {"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
-            }
+  {"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound},
+    "example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"},
+  },
+  "example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest},
+}
 
-// create replier based on error manifest
+// create Replier based on error manifest
 replier := reply.NewReplier(baseManifest)
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-    // error returned
-    exampleErr := errors.New("example-404-error")
+  // error returned
+  exampleErr := errors.New("example-404-error")
 
-    _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-        Writer: w,
-        Error:  exampleErr,
-    })
+  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+    Writer: w,
+    Error:  exampleErr,
+  })
 }
 ```
 
-For readability and simplicity, you can use the `HTTP error response aide`. You can find a code snippet using this aide below:
+If you wanted to send a `multi error response`, you could use the following, assuming the same `Replier` from above is being used:
+
+```go
+func ExampleHandler(w http.ResponseWriter, r *http.Request) {
+
+  // errors returned
+	exampleErrs := []errors{
+		errors.New("example-name-validation-error"),
+		errors.New("example-dob-validation-error"),
+	}
+
+	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+		Writer: w,
+		Errors: exampleErrs,
+	})
+}
+
+```
+
+For readability and simplicity, you can use the `HTTP error response aides`. You can find code snippets using these aides below:
+
+- `Individual Error`
 
 ```go
 // inside of the request handler
 _ = replier.NewHTTPErrorResponse(w, exampleErr)
 ```
 
+- `Multiple Errors`
+
+```go
+// inside of the request handler
+_ = replier.NewHTTPMultiErrorResponse(w, exampleErrs)
+```
+
 You can also add additional `headers` and `meta data` to the response by using the optional `WithHeaders` and/ or `WithMeta` response attributes respectively. For example:
 
 ```go
 _ = replier.NewHTTPErrorResponse(w, exampleErr, reply.WithMeta(map[string]interface{}{
-    "example": "meta in error reponse",
-}))
+		"example": "meta in error reponse",
+	}))
+```
+
+**OR**
+
+```go
+_ = replier.NewHTTPMultiErrorResponse(w, exampleErrs, reply.WithMeta(map[string]interface{}{
+		"example": "meta in error reponse",
+	}))
 ```
 
 #### JSON Representation
 
-`Error` responses are returned with the format.
+`Error` responses are returned with the format. The following responses are based on the examples above, so your response content will vary.
+
+- `Individual Error`
 
 ```JSON
 {
   "errors": [
     {
-      "title":  "resource not found",
+      "title": "resource not found",
       "status": "404"
+    }
+  ]
+}
+```
+
+- `Multiple Errors`
+
+```json
+{
+  "errors": [
+    {
+      "title": "Validation Error",
+      "detail": "The name provided does not meet validation requirements",
+      "about": "www.example.com/reply/validation/1011",
+      "status": "400",
+      "code": "1011"
+    },
+    {
+      "title": "Validation Error",
+      "detail": "The email provided does not meetvalidation requirements",
+      "status": "400"
     }
   ]
 }
@@ -270,23 +501,51 @@ _ = replier.NewHTTPErrorResponse(w, exampleErr, reply.WithMeta(map[string]interf
 
 When a `meta` is also declared, the response will have the following format. It can be as big or small as needed.
 
+- `Individual Error`
+
 ```JSON
 {
-    "meta": {
-        "example": "meta in error reponse"
+  "errors": [
+    {
+      "title": "resource not found",
+      "status": "404"
+    }
+  ],
+  "meta": {
+    "example": "meta in error reponse"
+  }
+}
+```
+
+- `Multiple Errors`
+
+```json
+{
+  "errors": [
+    {
+      "title": "Validation Error",
+      "detail": "The name provided does not meet validation requirements",
+      "about": "www.example.com/reply/validation/1011",
+      "status": "400",
+      "code": "1011"
     },
-    "errors": [
-      {
-        "title":  "resource not found",
-        "status": "404"
-      }
-    ]
+    {
+      "title": "Validation Error",
+      "detail": "The email provided does not meetvalidation requirements",
+      "status": "400"
+    }
+  ],
+  "meta": {
+    "example": "meta in error reponse"
+  }
 }
 ```
 
 ### Token Response Type
 
-The `token` response sends the consumer tokens; currently, the supported token types are `acccess_token` and `refresh_token`. If either is passed in the response request, `reply` will default to this response type.
+The `token` response sends the consumer tokens. Currently, it is limited to **2** tokens, and with the default `Transfer Object`, `TokenOne` represents `access_token`, and `TokenTwo` represents `refresh_token`. However, if you use other ID/ JSON attributes to describe your tokens for your API, you can [**create a `Custom Transfer Object`**](#transfer-objects).
+
+Again, when using the default `Transfer Object`, the supported `TokenOne` and `TokenTwo` represent `acccess_token` and `refresh_token`, respectively. If either is passed in the response request, `reply` will default to this response type.
 
 #### As code (including aide example)
 
@@ -297,14 +556,14 @@ replier := reply.NewReplier([]reply.ErrorManifest{})
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-    // do something to get tokens
+  // do something to get tokens
 
-    _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-        Writer: w,
-        AccessToken: "08a0a043-b532-4cea-8117-364739f2d994",
-        RefreshToken: "08b29914-09a8-4a4a-8aa5-b1ffaff266e6",
-        StatusCode: 200,
-    })
+	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+		Writer:     w,
+		TokenOne:   "08a0a043-b532-4cea-8117-364739f2d994",
+		TokenTwo:   "08b29914-09a8-4a4a-8aa5-b1ffaff266e6",
+		StatusCode: 200,
+	})
 }
 ```
 
@@ -318,12 +577,12 @@ _ = replier.NewHTTPTokenResponse(w, 200, "08a0a043-b532-4cea-8117-364739f2d994",
 You can also add additional `headers` and `meta data` to the response by using the optional `WithHeaders` and/ or `WithMeta` response attributes respectively. For example:
 
 ```go
-_ = replier.NewHTTPErrorResponse(w, 200, "08a0a043-b532-4cea-8117-364739f2d994", "08b29914-09a8-4a4a-8aa5-b1ffaff266e6", reply.WithMeta(map[string]interface{}{
-    "example": "meta in token reponse",
+_ = replier.NewHTTPTokenResponse(w, 200, "08a0a043-b532-4cea-8117-364739f2d994", "08b29914-09a8-4a4a-8aa5-b1ffaff266e6", reply.WithMeta(map[string]interface{}{
+ "example": "meta in token reponse",
 }))
 ```
 
-> NOTE: If you only want to return one token, pass an empty string, i.e. `""`. Although, it is important that you give at least one token string. 
+> NOTE: If you only want to return one token, pass an empty string, i.e. `""`. Although, you must give at least one token string. 
 
 #### JSON Representation
 
@@ -331,8 +590,8 @@ _ = replier.NewHTTPErrorResponse(w, 200, "08a0a043-b532-4cea-8117-364739f2d994",
 
 ```JSON
 {
-    "access_token": "08a0a043-b532-4cea-8117-364739f2d994",
-    "refresh_token": "08b29914-09a8-4a4a-8aa5-b1ffaff266e6"
+  "access_token": "08a0a043-b532-4cea-8117-364739f2d994",
+  "refresh_token": "08b29914-09a8-4a4a-8aa5-b1ffaff266e6"
 }
 ```
 
@@ -342,11 +601,11 @@ When a `meta` is also declared, the response will have the following format. It 
 
 ```JSON
 {
-    "meta": {
-        "example": "meta in token reponse"
-    },
-    "access_token": "08a0a043-b532-4cea-8117-364739f2d994",
-    "refresh_token": "08b29914-09a8-4a4a-8aa5-b1ffaff266e6"
+  "access_token": "08a0a043-b532-4cea-8117-364739f2d994",
+  "refresh_token": "08b29914-09a8-4a4a-8aa5-b1ffaff266e6",
+  "meta": {
+    "example": "meta in token reponse"
+  }
 }
 ```
 
@@ -363,26 +622,26 @@ To create a `data` response use the following code snippet:
 
 ```go
 type user struct {
-    id int `json:"id"`
-    name string `json:"name"`
-    dob string `json:"dob"`
+  id   int    `json:"id"`
+  name string `json:"name"`
+  dob  string `json:"dob"`
 }
 
 replier := reply.NewReplier([]reply.ErrorManifest{})
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-    u := user{
-        id: 1,
-        name: "john doe",
-        dob: "1/1/1970",
-    }
+  u := user{
+		id:   1,
+		name: "john doe",
+		dob:  "1/1/1970",
+	}
 
-    _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-        Writer: w,
-        Data: u,
-        StatusCode: 201,
-    })
+	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+		Writer:     w,
+		Data:       u,
+		StatusCode: 201,
+	})
 }
 ```
 
@@ -398,8 +657,8 @@ You can also add additional `headers` and `meta data` to the response by using t
 
 ```go
 _ = replier.NewHTTPDataResponse(w, 201, u, reply.WithMeta(map[string]interface{}{
-    "example": "meta in data reponse",
-}))
+		"example": "meta in data reponse",
+	}))
 ```
 
 #### JSON Representation
@@ -408,11 +667,11 @@ _ = replier.NewHTTPDataResponse(w, 201, u, reply.WithMeta(map[string]interface{}
 
 ```JSON
 {
-    "data": {
-        "id": 1,
-        "name": "john doe",
-        "dob": "1/1/1970"
-    }
+  "data": {
+    "id": 1,
+    "name": "john doe",
+    "dob": "1/1/1970"
+  }
 }
 ```
 
@@ -422,14 +681,14 @@ When a `meta` is also declared, the response will have the following format. It 
 
 ```JSON
 {
-    "meta": {
-        "example": "meta in data reponse"
-    },
-     "data": {
-        "id": 1,
-        "name": "john doe",
-        "dob": "1/1/1970"
-    }
+  "data": {
+    "id": 1,
+    "name": "john doe",
+    "dob": "1/1/1970"
+  },
+  "meta": {
+    "example": "meta in data reponse"
+  }
 }
 ```
 
@@ -446,10 +705,10 @@ replier := reply.NewReplier([]reply.ErrorManifest{})
 
 func ExampleHandler(w http.ResponseWriter, r *http.Request) {
 
-    _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-        Writer:     w,
-        StatusCode: 200,
-    })
+  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+		Writer:     w,
+		StatusCode: 200,
+	})
 }
 ```
 
@@ -464,8 +723,8 @@ You can also add additional `headers` and `meta data` to the response by using t
 
 ```go
 _ = replier.NewHTTPBlankResponse(w, 200, reply.WithMeta(map[string]interface{}{
-    "example": "meta in default reponse",
-}))
+		"example": "meta in default reponse",
+	}))
 ```
 
 
@@ -475,7 +734,7 @@ _ = replier.NewHTTPBlankResponse(w, 200, reply.WithMeta(map[string]interface{}{
 
 ```JSON
 {
-    "data": "{}"
+  "data": "{}"
 }
 ```
 
@@ -485,10 +744,10 @@ When a `meta` is also declared, the response will have the following format. It 
 
 ```JSON
 {
-    "meta": {
-        "example": "meta in default reponse"
-    },
-     "data": "{}"
+  "data": "{}",
+  "meta": {
+    "example": "meta in default reponse"
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There are several ways you can integrate `reply` into your application. Below, y
 // (Optional) Create a error manifest, to hold correlating error as string and it's manifest
 // item
 baseManifest := []reply.ErrorManifest{
-                {"example-404-error": reply.ErrorManifestItem{Message: "resource not found", StatusCode: http.StatusNotFound}},
+                {"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
             }
 
 // Create replier to manage the responses going back to consumer(s)
@@ -91,9 +91,12 @@ When the endpoint linked to the handler above is called, you should see the foll
 ```JSON
 
 {
-    "status": {
-        "message": "resource not found"
+  "errors": [
+    {
+      "title":  "resource not found",
+      "status": "404"
     }
+  ]
 }
 ```
 
@@ -143,6 +146,8 @@ When the endpoint linked to the handler above is called, you should see the foll
 ```
 
 ### Transfer Objects
+
+### TODO: Update to include newly added `Transfer Object Error`
 
 A `Transfer object` defines the shape of the response. if desired, users can create their own `transfer object` with additional logic, but it must satisfy the following interface:
 
@@ -213,7 +218,7 @@ To create an `error` response use the following code snippet:
 ```go
 // create error manifest
 baseManifest := []reply.ErrorManifest{
-                {"example-404-error": reply.ErrorManifestItem{Message: "resource not found", StatusCode: http.StatusNotFound}},
+                {"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
             }
 
 // create replier based on error manifest
@@ -252,9 +257,12 @@ _ = replier.NewHTTPErrorResponse(w, exampleErr, reply.WithMeta(map[string]interf
 
 ```JSON
 {
-    "status": {
-        "message": "resource not found"
+  "errors": [
+    {
+      "title":  "resource not found",
+      "status": "404"
     }
+  ]
 }
 ```
 
@@ -267,9 +275,12 @@ When a `meta` is also declared, the response will have the following format. It 
     "meta": {
         "example": "meta in error reponse"
     },
-    "status": {
-        "message": "resource not found"
-    }
+    "errors": [
+      {
+        "title":  "resource not found",
+        "status": "404"
+      }
+    ]
 }
 ```
 

--- a/examples/example_simple_api.go
+++ b/examples/example_simple_api.go
@@ -183,7 +183,7 @@ type user struct {
 // Example implementation of Error Manifest
 var baseManifest []reply.ErrorManifest = []reply.ErrorManifest{
 	{"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
-	{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest}},
+	{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
 	{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
 }
 

--- a/examples/example_simple_api.go
+++ b/examples/example_simple_api.go
@@ -22,7 +22,7 @@ type fooReplyTransferObject struct {
 }
 
 type barEmbeddedExample struct {
-	Status       *reply.TransferObjectStatus `json:"status,omitempty"`
+	Errors       []reply.TransferObjectError `json:"errors,omitempty"`
 	Meta         map[string]interface{}      `json:"meta,omitempty"`
 	Data         interface{}                 `json:"data,omitempty"`
 	AccessToken  string                      `json:"access_token,omitempty"`
@@ -69,8 +69,8 @@ func (t *fooReplyTransferObject) RefreshTransferObject() reply.TransferObject {
 	return &fooReplyTransferObject{}
 }
 
-func (t *fooReplyTransferObject) SetStatus(transferObjectStatus *reply.TransferObjectStatus) {
-	t.Bar.Status = transferObjectStatus
+func (t *fooReplyTransferObject) SetErrors(transferObjectErrors []reply.TransferObjectError) {
+	t.Bar.Errors = transferObjectErrors
 }
 
 ////////////////////
@@ -81,7 +81,7 @@ type user struct {
 }
 
 var baseManifest []reply.ErrorManifest = []reply.ErrorManifest{
-	{"example-404-error": reply.ErrorManifestItem{Message: "resource not found", StatusCode: http.StatusNotFound}},
+	{"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
 }
 
 var replier *reply.Replier = reply.NewReplier(baseManifest)

--- a/examples/example_simple_api.go
+++ b/examples/example_simple_api.go
@@ -46,11 +46,11 @@ func (t *fooReplyTransferObject) SetWriter(writer http.ResponseWriter) {
 	t.HTTPWriter = writer
 }
 
-func (t *fooReplyTransferObject) SetAccessToken(token string) {
+func (t *fooReplyTransferObject) SetTokenOne(token string) {
 	t.Bar.AccessToken = token
 }
 
-func (t *fooReplyTransferObject) SetRefreshToken(token string) {
+func (t *fooReplyTransferObject) SetTokenTwo(token string) {
 	t.Bar.RefreshToken = token
 }
 
@@ -269,9 +269,9 @@ func simpleTokensAPIHandler(w http.ResponseWriter, r *http.Request) {
 	mockedRefreshToken := "0e95c426-d373-41a5-bfe1-08db322527bd"
 
 	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
-		Writer:       w,
-		AccessToken:  mockedAccessToken,
-		RefreshToken: mockedRefreshToken,
+		Writer:   w,
+		TokenOne: mockedAccessToken,
+		TokenTwo: mockedRefreshToken,
 	})
 }
 

--- a/examples/example_simple_api.go
+++ b/examples/example_simple_api.go
@@ -380,8 +380,8 @@ func handleRequest() {
 	http.HandleFunc("/users/4", simpleUsersAPINoManifestEntryHandler)
 	http.HandleFunc("/tokens/refresh", simpleTokensAPIHandler)
 	http.HandleFunc("/defaults/1", simpleAPIDefaultResponseHandler)
-	http.HandleFunc("/custom/users/3", simpleUsersAPINotFoundCustomReplierHandler)
-	http.HandleFunc("/custom/users/404", simpleUsersAPINotFoundWithCustomTransitionObjsHandler)
+	http.HandleFunc("/users/3/custom", simpleUsersAPINotFoundCustomReplierHandler)
+	http.HandleFunc("/users/404/custom", simpleUsersAPINotFoundWithCustomTransitionObjsHandler)
 
 	http.HandleFunc("/aides/errors", simpleUsersAPIMultiErrorUsingAideHandler)
 	http.HandleFunc("/aides/errors/custom", simpleUsersAPIMultiErrorUsingAideWithCustomErrorHandler)
@@ -390,7 +390,7 @@ func handleRequest() {
 	http.HandleFunc("/aides/users/4", simpleUsersAPINoManifestEntryUsingAideHandler)
 	http.HandleFunc("/aides/tokens/refresh", simpleTokensAPIUsingAideHandler)
 	http.HandleFunc("/aides/defaults/1", simpleAPIDefaultResponseUsingAideHandler)
-	http.HandleFunc("/aides/custom/users/3", simpleUsersAPINotFoundCustomReplierUsingAideHandler)
+	http.HandleFunc("/aides/users/3/custom", simpleUsersAPINotFoundCustomReplierUsingAideHandler)
 
 	log.Printf("Serving simple API on port %s...", port)
 	log.Fatal(http.ListenAndServe(port, nil))

--- a/examples/example_simple_api.go
+++ b/examples/example_simple_api.go
@@ -82,6 +82,8 @@ type user struct {
 
 var baseManifest []reply.ErrorManifest = []reply.ErrorManifest{
 	{"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
+	{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest}},
+	{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
 }
 
 var replier *reply.Replier = reply.NewReplier(baseManifest)
@@ -96,6 +98,17 @@ func simpleUsersAPINotFoundHandler(w http.ResponseWriter, r *http.Request) {
 	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
 		Writer: w,
 		Error:  serverErr,
+	})
+}
+
+func simpleUsersAPIMultiErrorHandler(w http.ResponseWriter, r *http.Request) {
+
+	// Do something with a server
+	serverErrs := []error{errors.New("example-dob-validation-error"), errors.New("example-name-validation-error")}
+
+	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+		Writer: w,
+		Errors: serverErrs,
 	})
 }
 
@@ -164,6 +177,14 @@ func simpleUsersAPINotFoundCustomReplierHandler(w http.ResponseWriter, r *http.R
 //////////////////////////////
 //// Handlers Using Aides ////
 
+func simpleUsersAPIMultiErrorUsingAideHandler(w http.ResponseWriter, r *http.Request) {
+
+	// Do something with a server
+	serverErrs := []error{errors.New("example-dob-validation-error"), errors.New("example-name-validation-error")}
+
+	_ = replier.NewHTTPMultiErrorResponse(w, serverErrs)
+}
+
 func simpleUsersAPINotFoundUsingAideHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Do something with a server
@@ -225,6 +246,7 @@ func simpleUsersAPINotFoundCustomReplierUsingAideHandler(w http.ResponseWriter, 
 func handleRequest() {
 	var port string = ":8081"
 
+	http.HandleFunc("/errors", simpleUsersAPIMultiErrorHandler)
 	http.HandleFunc("/users", simpleUsersAPIHandler)
 	http.HandleFunc("/users/3", simpleUsersAPINotFoundHandler)
 	http.HandleFunc("/users/4", simpleUsersAPINoManifestEntryHandler)
@@ -232,6 +254,7 @@ func handleRequest() {
 	http.HandleFunc("/defaults/1", simpleAPIDefaultResponseHandler)
 	http.HandleFunc("/custom/users/3", simpleUsersAPINotFoundCustomReplierHandler)
 
+	http.HandleFunc("/aides/errors", simpleUsersAPIMultiErrorUsingAideHandler)
 	http.HandleFunc("/aides/users", simpleUsersAPIUsingAideHandler)
 	http.HandleFunc("/aides/users/3", simpleUsersAPINotFoundUsingAideHandler)
 	http.HandleFunc("/aides/users/4", simpleUsersAPINoManifestEntryUsingAideHandler)

--- a/examples/example_simple_api.go
+++ b/examples/example_simple_api.go
@@ -180,17 +180,35 @@ type user struct {
 	Name string `json:"name"`
 }
 
+// Example implementation of Error Manifest
 var baseManifest []reply.ErrorManifest = []reply.ErrorManifest{
 	{"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
 	{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest}},
 	{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
 }
 
+// Replier with default Transition Object & Transition Object Error
 var replier *reply.Replier = reply.NewReplier(baseManifest)
 
+// Replier with custom Transition Object & default Transition Object Error
 var replierWithCustomTransitionObj *reply.Replier = reply.NewReplier(baseManifest, reply.WithTransferObject(&fooReplyTransferObject{}))
 
+// Replier with standard Transition Object & custom Transition Object Error
 var replierWithCustomTransitionObjError *reply.Replier = reply.NewReplier(baseManifest, reply.WithTransferObjectError(&barError{}))
+
+// Replier with custom Transition Object & custom Transition Object Error
+var replierWithCustomTransitionObjs *reply.Replier = reply.NewReplier(baseManifest, reply.WithTransferObjectError(&barError{}), reply.WithTransferObject(&fooReplyTransferObject{}))
+
+func simpleUsersAPINotFoundWithCustomTransitionObjsHandler(w http.ResponseWriter, r *http.Request) {
+
+	// Do something with a server
+	serverErr := errors.New("example-404-error")
+
+	_ = replierWithCustomTransitionObjs.NewHTTPResponse(&reply.NewResponseRequest{
+		Writer: w,
+		Error:  serverErr,
+	})
+}
 
 func simpleUsersAPINotFoundHandler(w http.ResponseWriter, r *http.Request) {
 
@@ -363,6 +381,7 @@ func handleRequest() {
 	http.HandleFunc("/tokens/refresh", simpleTokensAPIHandler)
 	http.HandleFunc("/defaults/1", simpleAPIDefaultResponseHandler)
 	http.HandleFunc("/custom/users/3", simpleUsersAPINotFoundCustomReplierHandler)
+	http.HandleFunc("/custom/users/404", simpleUsersAPINotFoundWithCustomTransitionObjsHandler)
 
 	http.HandleFunc("/aides/errors", simpleUsersAPIMultiErrorUsingAideHandler)
 	http.HandleFunc("/aides/errors/custom", simpleUsersAPIMultiErrorUsingAideWithCustomErrorHandler)

--- a/model.go
+++ b/model.go
@@ -4,46 +4,135 @@
 
 package reply
 
-import "net/http"
+import (
+	"net/http"
+	"strconv"
+)
 
 // ErrorManifestItem holds the message and status code for an error response
 type ErrorManifestItem struct {
 
-	// Message holds the text returned in the response's `status.message` path
+	// Title holds the text summary returned in the response's error response
 	//
 	// NOTE:
 	//
-	// - The most effective messages are short, sweet and easy to consume
+	// - The most effective title are short, sweet and easy to consume
 	//
 	// - This message will be seen by the consuming client, be mindful of
 	// the amount of information you divulge
-	Message string
+	Title string
+
+	// Detail holds a more descriptive brief returned in the response's error response
+	//
+	// NOTE:
+	//
+	// - Detail will give a deeper level of context, while being mindful of length
+	//
+	// - Like the title message will be seen by the consuming client, be mindful of
+	// the amount of information you divulge
+	Detail string
 
 	// StatusCode holds the HTTP status code that best relates to the response.
 	// For more information on status codes, https://httpstatuses.com/.
 	StatusCode int
+
+	// About holds the a URL that gives further insight into the error
+	About string
+
+	// Code holds the internal application error code, if appicable, thst is used to
+	// help debuggers better identify error
+	Code string
+
+	// Meta contains additional meta-information about the that can be shared to
+	// consumer
+	Meta interface{}
 }
 
 // ErrorManifest holds error reference (string) with its corresponding
 // manifest item (message & status code) which it returned in the response
 type ErrorManifest map[string]ErrorManifestItem
 
-// TransferObjectStatus holds attributes often used to give additional
-// context in responses
-type TransferObjectStatus struct {
-	Errors  []Error `json:"errors,omitempty"`
-	Message string  `json:"message,omitempty"`
-}
-
-// SetMessage adds message to transfer object status
-func (s *TransferObjectStatus) SetMessage(message string) {
-	s.Message = message
-}
-
-// Error holds the associated code and detail for errors passed
+// Error holds attributes often used to give additional
+// context when unexpected behaviour occurs
 type Error struct {
-	Code    string `json:"code"`
-	Details string `json:"details"`
+
+	// Title a short summary of the problem
+	Title string `json:"title,omitempty"`
+
+	// Detail a description of the error
+	Detail string `json:"detail,omitempty"`
+
+	// About holds the link that gives further insight into the error
+	About string `json:"about,omitempty"`
+
+	// Status the HTTP status associated with error
+	Status string `json:"status,omitempty"`
+
+	// Code internal error code used to reference error
+	Code string `json:"code,omitempty"`
+
+	// Meta contains additional meta-information about the error
+	Meta interface{} `json:"meta,omitempty"`
+}
+
+// SetTitle adds title to error
+func (e *Error) SetTitle(title string) {
+	e.Title = title
+}
+
+// GetTitle returns error's title
+func (e *Error) GetTitle() string {
+	return e.Title
+}
+
+// SetDetail adds detail to error
+func (e *Error) SetDetail(detail string) {
+	e.Detail = detail
+}
+
+// GetDetail return error's detail
+func (e *Error) GetDetail() string {
+	return e.Detail
+}
+
+// SetAbout adds about to error
+func (e *Error) SetAbout(about string) {
+	e.About = about
+}
+
+// GetAbout return error's about
+func (e *Error) GetAbout() string {
+	return e.About
+}
+
+// SetStatusCode converts and add http status code to error
+func (e *Error) SetStatusCode(status int) {
+	e.Status = strconv.Itoa(status)
+}
+
+// GetStatusCode returns error's HTTP status code
+func (e *Error) GetStatusCode() string {
+	return e.Status
+}
+
+// SetCode adds internal code to error
+func (e *Error) SetCode(code string) {
+	e.Code = code
+}
+
+// GetCode returns error's internal code
+func (e *Error) GetCode() string {
+	return e.Code
+}
+
+// SetMeta adds meta property to error
+func (e *Error) SetMeta(meta interface{}) {
+	e.Meta = meta
+}
+
+// GetMeta returns error's meta property
+func (e *Error) GetMeta() interface{} {
+	return e.Meta
 }
 
 // defaultReplyTransferObject handles structing response for client
@@ -52,7 +141,7 @@ type defaultReplyTransferObject struct {
 	HTTPWriter   http.ResponseWriter    `json:"-"`
 	Headers      map[string]string      `json:"-"`
 	StatusCode   int                    `json:"-"`
-	Status       *TransferObjectStatus  `json:"status,omitempty"`
+	Errors       []TransferObjectError  `json:"errors,omitempty"`
 	Meta         map[string]interface{} `json:"meta,omitempty"`
 	Data         interface{}            `json:"data,omitempty"`
 	AccessToken  string                 `json:"access_token,omitempty"`
@@ -111,7 +200,7 @@ func (t *defaultReplyTransferObject) RefreshTransferObject() TransferObject {
 	return &defaultReplyTransferObject{}
 }
 
-// SetStatus assigns the passed transfer object status to the transfer object
-func (t *defaultReplyTransferObject) SetStatus(transferObjectStatus *TransferObjectStatus) {
-	t.Status = transferObjectStatus
+// SetErrors assigns the passed transfer object errors to the transfer object
+func (t *defaultReplyTransferObject) SetErrors(transferObjectErrors []TransferObjectError) {
+	t.Errors = transferObjectErrors
 }

--- a/model.go
+++ b/model.go
@@ -52,9 +52,9 @@ type ErrorManifestItem struct {
 // manifest item (message & status code) which it returned in the response
 type ErrorManifest map[string]ErrorManifestItem
 
-// Error holds attributes often used to give additional
+// defaultReplyTransferObjectError holds attributes often used to give additional
 // context when unexpected behaviour occurs
-type Error struct {
+type defaultReplyTransferObjectError struct {
 
 	// Title a short summary of the problem
 	Title string `json:"title,omitempty"`
@@ -76,69 +76,69 @@ type Error struct {
 }
 
 // SetTitle adds title to error
-func (e *Error) SetTitle(title string) {
+func (e *defaultReplyTransferObjectError) SetTitle(title string) {
 	e.Title = title
 }
 
 // GetTitle returns error's title
-func (e *Error) GetTitle() string {
+func (e *defaultReplyTransferObjectError) GetTitle() string {
 	return e.Title
 }
 
 // SetDetail adds detail to error
-func (e *Error) SetDetail(detail string) {
+func (e *defaultReplyTransferObjectError) SetDetail(detail string) {
 	e.Detail = detail
 }
 
 // GetDetail return error's detail
-func (e *Error) GetDetail() string {
+func (e *defaultReplyTransferObjectError) GetDetail() string {
 	return e.Detail
 }
 
 // SetAbout adds about to error
-func (e *Error) SetAbout(about string) {
+func (e *defaultReplyTransferObjectError) SetAbout(about string) {
 	e.About = about
 }
 
 // GetAbout return error's about
-func (e *Error) GetAbout() string {
+func (e *defaultReplyTransferObjectError) GetAbout() string {
 	return e.About
 }
 
 // SetStatusCode converts and add http status code to error
-func (e *Error) SetStatusCode(status int) {
+func (e *defaultReplyTransferObjectError) SetStatusCode(status int) {
 	e.Status = strconv.Itoa(status)
 }
 
 // GetStatusCode returns error's HTTP status code
-func (e *Error) GetStatusCode() string {
+func (e *defaultReplyTransferObjectError) GetStatusCode() string {
 	return e.Status
 }
 
 // SetCode adds internal code to error
-func (e *Error) SetCode(code string) {
+func (e *defaultReplyTransferObjectError) SetCode(code string) {
 	e.Code = code
 }
 
 // GetCode returns error's internal code
-func (e *Error) GetCode() string {
+func (e *defaultReplyTransferObjectError) GetCode() string {
 	return e.Code
 }
 
 // SetMeta adds meta property to error
-func (e *Error) SetMeta(meta interface{}) {
+func (e *defaultReplyTransferObjectError) SetMeta(meta interface{}) {
 	e.Meta = meta
 }
 
 // GetMeta returns error's meta property
-func (e *Error) GetMeta() interface{} {
+func (e *defaultReplyTransferObjectError) GetMeta() interface{} {
 	return e.Meta
 }
 
 // RefreshTransferObject returns an empty instance of transfer object
 // error
-func (e *Error) RefreshTransferObject() TransferObjectError {
-	return &Error{}
+func (e *defaultReplyTransferObjectError) RefreshTransferObject() TransferObjectError {
+	return &defaultReplyTransferObjectError{}
 }
 
 // defaultReplyTransferObject handles structing response for client
@@ -148,10 +148,10 @@ type defaultReplyTransferObject struct {
 	Headers      map[string]string      `json:"-"`
 	StatusCode   int                    `json:"-"`
 	Errors       []TransferObjectError  `json:"errors,omitempty"`
-	Meta         map[string]interface{} `json:"meta,omitempty"`
 	Data         interface{}            `json:"data,omitempty"`
 	AccessToken  string                 `json:"access_token,omitempty"`
 	RefreshToken string                 `json:"refresh_token,omitempty"`
+	Meta         map[string]interface{} `json:"meta,omitempty"`
 }
 
 // SetHeaders adds headers to transfer object

--- a/model.go
+++ b/model.go
@@ -135,6 +135,12 @@ func (e *Error) GetMeta() interface{} {
 	return e.Meta
 }
 
+// RefreshTransferObject returns an empty instance of transfer object
+// error
+func (e *Error) RefreshTransferObject() TransferObjectError {
+	return &Error{}
+}
+
 // defaultReplyTransferObject handles structing response for client
 // consumption
 type defaultReplyTransferObject struct {

--- a/model.go
+++ b/model.go
@@ -144,14 +144,14 @@ func (e *defaultReplyTransferObjectError) RefreshTransferObject() TransferObject
 // defaultReplyTransferObject handles structing response for client
 // consumption
 type defaultReplyTransferObject struct {
-	HTTPWriter   http.ResponseWriter    `json:"-"`
-	Headers      map[string]string      `json:"-"`
-	StatusCode   int                    `json:"-"`
-	Errors       []TransferObjectError  `json:"errors,omitempty"`
-	Data         interface{}            `json:"data,omitempty"`
-	AccessToken  string                 `json:"access_token,omitempty"`
-	RefreshToken string                 `json:"refresh_token,omitempty"`
-	Meta         map[string]interface{} `json:"meta,omitempty"`
+	HTTPWriter http.ResponseWriter    `json:"-"`
+	Headers    map[string]string      `json:"-"`
+	StatusCode int                    `json:"-"`
+	Errors     []TransferObjectError  `json:"errors,omitempty"`
+	Data       interface{}            `json:"data,omitempty"`
+	TokenOne   string                 `json:"access_token,omitempty"`
+	TokenTwo   string                 `json:"refresh_token,omitempty"`
+	Meta       map[string]interface{} `json:"meta,omitempty"`
 }
 
 // SetHeaders adds headers to transfer object
@@ -176,14 +176,14 @@ func (t *defaultReplyTransferObject) SetWriter(writer http.ResponseWriter) {
 	t.HTTPWriter = writer
 }
 
-// SetAccessToken adds token to access token property on transfer object
-func (t *defaultReplyTransferObject) SetAccessToken(token string) {
-	t.AccessToken = token
+// SetTokenOne sets token value to token one on transfer object
+func (t *defaultReplyTransferObject) SetTokenOne(token string) {
+	t.TokenOne = token
 }
 
-// SetRefreshToken adds token to refresh token property on transfer object
-func (t *defaultReplyTransferObject) SetRefreshToken(token string) {
-	t.RefreshToken = token
+// SetTokenTwo sets token value to token two on transfer object
+func (t *defaultReplyTransferObject) SetTokenTwo(token string) {
+	t.TokenTwo = token
 }
 
 // GetWriter returns the writer assigned with the transfer object

--- a/model.go
+++ b/model.go
@@ -39,7 +39,7 @@ type ErrorManifestItem struct {
 	// About holds the a URL that gives further insight into the error
 	About string
 
-	// Code holds the internal application error code, if appicable, thst is used to
+	// Code holds the internal application error code, if appicable, that is used to
 	// help debuggers better identify error
 	Code string
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,18 @@
 # Reply Release Notes
 
+## [v1.0.0](https://github.com/ooaklee/reply/releases/tag/v1.0.0)
+2021-09-11
+
+* Update top-level response members from `meta`, `status` and `data` **->** `meta`, `errors` and `data`
+* Updated `Manifest Error Item` fields
+* Updated logic & added new aide `NewHTTPMultiErrorResponse` to support multiple error response objects in response
+* Refactored code
+* Added logic to support users passing custom *error transfer objects* (`TransferObjectError`), `reply.WithTransferObjectError`
+  * Added `RefreshTransferObject` method call to `TransferObjectError`
+* Updated Token attributes & methods on base `Transfer Object` to have a generic name to cover cases where API uses different token identifiers
+  * `AccessToken` -> `TokenOne` & `RefreshToken` -> `TokenTwo`
+* Added logic to set `StatusCode` if not set already. Defaults to `400`.
+  
 ## [v1.0.0-alpha.3](https://github.com/ooaklee/reply/releases/tag/v1.0.0-alpha.3)
 2021-09-11
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -3,11 +3,11 @@
 ## [v1.0.0-alpha.3](https://github.com/ooaklee/reply/releases/tag/v1.0.0-alpha.3)
 2021-09-11
 
-* Refactor Token attributes & methods to have a more general name to make use of cases where API uses different token identifier less confusing
+* Refactor Token attributes & methods to have a more general name to make use of cases where API uses different token identifiers less confusing
   * `AccessToken` -> `TokenOne` & `RefreshToken` -> `TokenTwo`
     * Dev can create custom `TransferObject` to set JSON attribute to match their use case
 * Added logic to set `StatusCode` if not set already. Defaults to `400`.
-* Updated README to better describe library
+* Updated README to better describe the library
 
 ## [v1.0.0-alpha.2](https://github.com/ooaklee/reply/releases/tag/v1.0.0-alpha.2)
 2021-09-10

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,14 @@
 # Reply Release Notes
 
+## [v1.0.0-alpha.3](https://github.com/ooaklee/reply/releases/tag/v1.0.0-alpha.3)
+2021-09-11
+
+* Refactor Token attributes & methods to have a more general name to make use of cases where API uses different token identifier less confusing
+  * `AccessToken` -> `TokenOne` & `RefreshToken` -> `TokenTwo`
+    * Dev can create custom `TransferObject` to set JSON attribute to match their use case
+* Added logic to set `StatusCode` if not set already. Defaults to `400`.
+* Updated README to better describe library
+
 ## [v1.0.0-alpha.2](https://github.com/ooaklee/reply/releases/tag/v1.0.0-alpha.2)
 2021-09-10
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,12 @@
 # Reply Release Notes
 
+## [v1.0.0-alpha.2](https://github.com/ooaklee/reply/releases/tag/v1.0.0-alpha.2)
+2021-09-10
+
+* Refactored logic to allow users to pass custom error transfer objects (TransferObjectError), `reply.WithTransferObjectError`
+  * Added `RefreshTransferObject` method call to `TransferObjectError`
+* Updated `example simple api` to use the new Replier Option and update the `transfer object error`
+
 ## [v1.0.0-alpha.1](https://github.com/ooaklee/reply/releases/tag/v1.0.0-alpha.1)
 2021-09-10
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,36 @@
 # Reply Release Notes
 
+## [v1.0.0-alpha.1](https://github.com/ooaklee/reply/releases/tag/v1.0.0-alpha.1)
+2021-09-10
+
+* Added new aide `NewHTTPMultiErrorResponse` to support multiple error response
+* Updated `example simple api` to use the new aide `NewHTTPMultiErrorResponse`
+* Added logic to handle/ create multiple error response
+* Refactor code to make it more readable with new logic
+
+## [v1.0.0-alpha](https://github.com/ooaklee/reply/releases/tag/v1.0.0-alpha)
+2021-09-09
+
+* Update top-level response members from `meta`, `status` and `data` **->** `meta`, `errors` and `data`
+* Updated underlying logic to how an error is handled
+* Updated `Manifest Error Item` attributes
+
+## [v0.2.0](https://github.com/ooaklee/reply/releases/tag/v0.2.0)
+2021-09-04
+
+* Fixed bug in logic for merging error manifests
+* Added helper functions (aides) to help users more efficiently use the library
+
+## [v0.2.0-alpha.1](https://github.com/ooaklee/reply/releases/tag/v0.2.0-alpha.1)
+2021-09-04
+
+* Fixed bug in logic for merging error manifests
+
+## [v0.2.0-alpha](https://github.com/ooaklee/reply/releases/tag/v0.2.0-alpha)
+2021-09-03
+
+* Initial logic for helper functions (`aides`) to help users more efficiently use the library
+
 ## [v0.1.1](https://github.com/ooaklee/reply/releases/tag/v0.1.1)
 2021-08-31
 

--- a/replier.go
+++ b/replier.go
@@ -110,7 +110,7 @@ type Replier struct {
 func NewReplier(manifests []ErrorManifest, options ...Option) *Replier {
 
 	activeTransferObject := &defaultReplyTransferObject{}
-	activeTransferObjectError := &Error{}
+	activeTransferObjectError := &defaultReplyTransferObjectError{}
 
 	replier := Replier{
 		errorManifest:       mergeManifestCollections(manifests),

--- a/replier.go
+++ b/replier.go
@@ -46,27 +46,27 @@ type TransferObject interface {
 }
 
 const (
-	// defaultResponseBody returns default response body
+	// defaultResponseBody is the default response body
 	defaultResponseBody = "{}"
 
-	// defaultStatusCode returns default response status code
+	// defaultStatusCode is the default response status code
 	defaultStatusCode = http.StatusOK
 
-	// defaultErrorsStatusCode returns default status code for errors
+	// defaultErrorsStatusCode is the default status code for errors
 	defaultErrorsStatusCode = http.StatusBadRequest
 )
 
-// Option used to build on top of default features
+// Option used to build on top of default Replier features
 type Option func(*Replier)
 
-// WithTransferObject overwrites the transfer object used for response
+// WithTransferObject sets the base transfer object used for response
 func WithTransferObject(replacementTransferObject TransferObject) Option {
 	return func(r *Replier) {
 		r.transferObject = replacementTransferObject
 	}
 }
 
-// WithTransferObjectError overwrites the transfer object used to represent
+// WithTransferObjectError sets the transfer object error used to represent
 // errors in response
 func WithTransferObjectError(replacementTransferObjectError TransferObjectError) Option {
 	return func(r *Replier) {
@@ -90,12 +90,23 @@ type NewResponseRequest struct {
 
 // Replier handles managing responses
 type Replier struct {
-	errorManifest       ErrorManifest
-	transferObject      TransferObject
+	// Error manifest used by Replier to pull corresponsing error items to build
+	// response error(s).
+	errorManifest ErrorManifest
+
+	// Top-level response base with core and special attributes used to build out
+	// response.
+	transferObject TransferObject
+
+	// Error object base used to shape error objects in response
 	transferObjectError TransferObjectError
 }
 
-// NewReplier creates a replier
+// NewReplier returns a new Replier pointer that shapes and handles both
+// successful and error based responses.
+//
+// NOTE - Both default object(s) can be overwritten using the  chained Options, i.e.
+// `WithTransferObject` or `WithTransferObjectError`
 func NewReplier(manifests []ErrorManifest, options ...Option) *Replier {
 
 	activeTransferObject := &defaultReplyTransferObject{}
@@ -301,7 +312,7 @@ func (r *Replier) convertErrorManifestItemToTransferObjectError(errorItem ErrorM
 // getAppropiateStatusCodeOrDefault loops through collection of transfer object errors (first to last), and
 // attempts to pull and convert status code (string).
 //
-// NOTE: If error occurs the next element will be attempted. In the event no elements are left, the default
+// NOTE - If error occurs the next element will be attempted. In the event no elements are left, the default
 // error status code (400) will be returned
 func getAppropiateStatusCodeOrDefault(transferObjectErrors []TransferObjectError) int {
 
@@ -397,7 +408,7 @@ func WithMeta(meta map[string]interface{}) ResponseAttributes {
 // With this aide, if desired, you can add additional attributes by using the
 // WithHeaders and/ or WithMeta optional response attributes.
 //
-// Note: If ANY of the passed errors do not have a manifest entry, a single
+// NOTE - If ANY of the passed errors do not have a manifest entry, a single
 // 500 error will be returned.
 func (r *Replier) NewHTTPMultiErrorResponse(w http.ResponseWriter, errs []error, attributes ...ResponseAttributes) error {
 
@@ -421,7 +432,7 @@ func (r *Replier) NewHTTPMultiErrorResponse(w http.ResponseWriter, errs []error,
 // With this aide, if desired, you can add additional attributes by using the
 // WithHeaders and/ or WithMeta optional response attributes.
 //
-// Note: If the passed error doesn't have a manifest entry, a 500 error will
+// NOTE - If the passed error doesn't have a manifest entry, a 500 error will
 // be returned.
 func (r *Replier) NewHTTPErrorResponse(w http.ResponseWriter, err error, attributes ...ResponseAttributes) error {
 
@@ -490,7 +501,7 @@ func (r *Replier) NewHTTPBlankResponse(w http.ResponseWriter, statusCode int, at
 // With this aide, if desired, you can add additional attributes by using the
 // WithHeaders and/ or WithMeta optional response attributes.
 //
-// Note: At least one of the tokens must be specified or an error will
+// NOTE - At least one of the tokens must be specified or an error will
 // be returned
 func (r *Replier) NewHTTPTokenResponse(w http.ResponseWriter, statusCode int, accessToken, refreshToken string, attributes ...ResponseAttributes) error {
 

--- a/replier.go
+++ b/replier.go
@@ -251,6 +251,8 @@ func (r *Replier) getErrorManifestItem(err error) ErrorManifestItem {
 		log.Printf("reply/error-response: failed to find error manifest item for %v", err)
 	}
 
+	// TODO: Set default error status Code on manifest item if unset
+
 	return manifestItem
 }
 

--- a/replier.go
+++ b/replier.go
@@ -35,8 +35,8 @@ type TransferObject interface {
 	SetHeaders(headers map[string]string)
 	SetStatusCode(code int)
 	SetMeta(meta map[string]interface{})
-	SetAccessToken(token string)
-	SetRefreshToken(token string)
+	SetTokenOne(token string)
+	SetTokenTwo(token string)
 	GetWriter() http.ResponseWriter
 	GetStatusCode() int
 	SetWriter(writer http.ResponseWriter)
@@ -76,16 +76,16 @@ func WithTransferObjectError(replacementTransferObjectError TransferObjectError)
 
 // NewResponseRequest holds attributes for response
 type NewResponseRequest struct {
-	Writer       http.ResponseWriter
-	Data         interface{}
-	Meta         map[string]interface{}
-	Headers      map[string]string
-	StatusCode   int
-	Message      string
-	Error        error
-	Errors       []error
-	AccessToken  string
-	RefreshToken string
+	Writer     http.ResponseWriter
+	Data       interface{}
+	Meta       map[string]interface{}
+	Headers    map[string]string
+	StatusCode int
+	Message    string
+	Error      error
+	Errors     []error
+	TokenOne   string
+	TokenTwo   string
 }
 
 // Replier handles managing responses
@@ -163,8 +163,8 @@ func (r *Replier) NewHTTPResponse(response *NewResponseRequest) error {
 	}
 
 	// Manage response for token
-	if response.AccessToken != "" || response.RefreshToken != "" {
-		return r.generateTokenResponse(response.AccessToken, response.RefreshToken)
+	if response.TokenOne != "" || response.TokenTwo != "" {
+		return r.generateTokenResponse(response.TokenOne, response.TokenTwo)
 	}
 
 	// Manage response for data
@@ -190,9 +190,9 @@ func (r *Replier) generateDataResponse(data interface{}) error {
 }
 
 // generateTokenResponse generates token response on passed tokens information
-func (r *Replier) generateTokenResponse(accessToken, refreshToken string) error {
-	r.transferObject.SetAccessToken(accessToken)
-	r.transferObject.SetRefreshToken(refreshToken)
+func (r *Replier) generateTokenResponse(tokenOne, tokenTwo string) error {
+	r.transferObject.SetTokenOne(tokenOne)
+	r.transferObject.SetTokenTwo(tokenTwo)
 
 	return sendHTTPResponse(r.transferObject.GetWriter(), r.transferObject)
 }
@@ -505,17 +505,17 @@ func (r *Replier) NewHTTPBlankResponse(w http.ResponseWriter, statusCode int, at
 //
 // NOTE - At least one of the tokens must be specified or an error will
 // be returned
-func (r *Replier) NewHTTPTokenResponse(w http.ResponseWriter, statusCode int, accessToken, refreshToken string, attributes ...ResponseAttributes) error {
+func (r *Replier) NewHTTPTokenResponse(w http.ResponseWriter, statusCode int, tokenOne, tokenTwo string, attributes ...ResponseAttributes) error {
 
-	if isEmpty(accessToken) && isEmpty(refreshToken) {
+	if isEmpty(tokenOne) && isEmpty(tokenTwo) {
 		return errors.New("reply/http-token-aide: failed at least one token must be returned")
 	}
 
 	request := NewResponseRequest{
-		Writer:       w,
-		StatusCode:   statusCode,
-		AccessToken:  accessToken,
-		RefreshToken: refreshToken,
+		Writer:     w,
+		StatusCode: statusCode,
+		TokenOne:   tokenOne,
+		TokenTwo:   tokenTwo,
 	}
 
 	// Add attributes to response request

--- a/replier.go
+++ b/replier.go
@@ -251,9 +251,17 @@ func (r *Replier) getErrorManifestItem(err error) ErrorManifestItem {
 		log.Printf("reply/error-response: failed to find error manifest item for %v", err)
 	}
 
-	// TODO: Set default error status Code on manifest item if unset
+	setDefaultStatusCode(&manifestItem)
 
 	return manifestItem
+}
+
+// setDefaultStatusCode sets the error manifest item's status code to default error
+// code value if it is not already set (non-zero)
+func setDefaultStatusCode(item *ErrorManifestItem) {
+	if item.StatusCode == 0 {
+		item.StatusCode = defaultErrorsStatusCode
+	}
 }
 
 // setUniversalAttributes sets the attributes that are common across all

--- a/replier_test.go
+++ b/replier_test.go
@@ -186,10 +186,10 @@ func TestReplier_NewHTTPResponseForError(t *testing.T) {
 		{
 			name: "Success - Resource not found",
 			manifests: append([]reply.ErrorManifest{
-				{"test-404-error": reply.ErrorManifestItem{Message: "resource not found", StatusCode: http.StatusNotFound}},
+				{"test-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
 			},
 				reply.ErrorManifest{
-					"test-401-error": reply.ErrorManifestItem{Message: "unauthorized", StatusCode: http.StatusUnauthorized},
+					"test-401-error": reply.ErrorManifestItem{Title: "unauthorized", StatusCode: http.StatusUnauthorized},
 				},
 			),
 			err:                errors.New("test-404-error"),
@@ -260,10 +260,10 @@ func TestReplier_AideNewHTTPErrorResponse(t *testing.T) {
 		{
 			name: "Success - Resource not found",
 			manifests: append([]reply.ErrorManifest{
-				{"test-404-error": reply.ErrorManifestItem{Message: "resource not found", StatusCode: http.StatusNotFound}},
+				{"test-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
 			},
 				reply.ErrorManifest{
-					"test-401-error": reply.ErrorManifestItem{Message: "unauthorized", StatusCode: http.StatusUnauthorized},
+					"test-401-error": reply.ErrorManifestItem{Title: "unauthorized", StatusCode: http.StatusUnauthorized},
 				},
 			),
 			err:                errors.New("test-404-error"),

--- a/replier_test.go
+++ b/replier_test.go
@@ -104,10 +104,10 @@ func TestReplier_NewHTTPResponseForTokens(t *testing.T) {
 			replier := reply.NewReplier(test.manifests)
 
 			replier.NewHTTPResponse(&reply.NewResponseRequest{
-				Writer:       w,
-				StatusCode:   test.StatusCode,
-				AccessToken:  test.accessToken,
-				RefreshToken: test.refreshToken,
+				Writer:     w,
+				StatusCode: test.StatusCode,
+				TokenOne:   test.accessToken,
+				TokenTwo:   test.refreshToken,
 			})
 
 			assert.Equal(t, test.expectedStatusCode, w.Code)

--- a/replier_test.go
+++ b/replier_test.go
@@ -5,10 +5,8 @@
 package reply_test
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,149 +15,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type baseTestResponse struct {
-	AccessToken  string      `json:"access_token,omitempty"`
-	RefreshToken string      `json:"refresh_token,omitempty"`
-	Data         interface{} `json:"data,omitempty"`
-}
-
-type baseStatusMessageResponse struct {
-	Status struct {
-		Message string `json:"message,omitempty"`
-	} `json:"status,omitempty"`
-}
-
+// user mock data object to return
 type user struct {
 	ID   string `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
-}
-
-// stringWithNewLine appends new line to passed string
-func stringWithNewLine(s string) string {
-	return fmt.Sprintf("%s\n", s)
-}
-
-// getDefaultHeader returns default headers
-func getDefaultHeader() http.Header {
-	return http.Header{"Content-Type": []string{"application/json"}}
-}
-
-// getAdditionalHeaders returns default header with addition correlation ID header
-func getAdditionalHeaders() http.Header {
-	return http.Header{"Content-Type": []string{"application/json"}, "Correlation-Id": []string{"some-id"}}
-}
-
-// getEmptyErrorManifest returns an empty manifest
-func getEmptyErrorManifest() []reply.ErrorManifest {
-	return []reply.ErrorManifest{}
-}
-
-// getDefaultErrorManifest returns the default manifest
-func getDefaultErrorManifest() []reply.ErrorManifest {
-	return []reply.ErrorManifest{
-		{"example-404-error": reply.ErrorManifestItem{Title: "Resource Not Found", StatusCode: http.StatusNotFound}},
-		{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
-		{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
-	}
-}
-
-// getMultiErrors returns example errors
-func getMultiErrors() []error {
-	return []error{
-		errors.New("example-dob-validation-error"),
-		errors.New("example-name-validation-error"),
-	}
-}
-
-// getMultiErrorsWithMissingErr returns example errors with one error
-// that does not exist in manifest
-func getMultiErrorsWithMissingErr() []error {
-	return append(getMultiErrors(), errors.New("example-missing-error"))
-}
-
-// getExampleErrorOne returns example error (1)
-func getExampleErrorOne() error {
-	return errors.New("example-404-error")
-}
-
-// getBlankResponseBody returns default blank response body
-func getBlankResponseBody() string {
-	return `{"data":"{}"}`
-}
-
-// getBlankResponseWithMetaBody returns default blank response body with meta-data
-func getBlankResponseWithMetaBody() string {
-	return `{"data":"{}","meta":{"example":"meta in response"}}`
-}
-
-// getDataResponseBody returns test data response body
-func getDataResponseBody() string {
-	return `{"data":{"id":"some-id","name":"john doe"}}`
-}
-
-// getDataResponseWithMetaBody returns test data response body with meta-data
-func getDataResponseWithMetaBody() string {
-	return `{"data":{"id":"some-id","name":"john doe"},"meta":{"example":"meta in response"}}`
-}
-
-// getFullTokenResponseBody returns test full token response body
-func getFullTokenResponseBody() string {
-	return `{"access_token":"test-token-1","refresh_token":"test-token-2"}`
-}
-
-// getSingleTokenResponseBody returns test single token response body
-func getSingleTokenResponseBody() string {
-	return `{"access_token":"test-token-1"}`
-}
-
-// getFullTokenResponseWithMetaBody returns test  full token response body with meta-data
-func getFullTokenResponseWithMetaBody() string {
-	return `{"access_token":"test-token-1","refresh_token":"test-token-2","meta":{"example":"meta in response"}}`
-}
-
-// getErrorResponseBody returns internal server error response body
-func getErrorResponseISEBody() string {
-	return `{"errors":[{"title":"Internal Server Error","status":"500"}]}`
-}
-
-// getErrorResponseForExampleErrorOne returns test error response body for getErrorResponseForExampleErrorOne function
-func getErrorResponseForExampleErrorOne() string {
-	return `{"errors":[{"title":"Resource Not Found","status":"404"}]}`
-}
-
-// getMultiErrorResponseMultiErrors returns test error response body for getMultiErrors function
-func getMultiErrorResponseMultiErrors() string {
-	return `{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}]}`
-}
-
-// getErrorResponseForExampleErrorOneWithMetaBody returns test error response body for getErrorResponseForExampleErrorOne function with meta-data
-func getErrorResponseForExampleErrorOneWithMetaBody() string {
-	return `{"errors":[{"title":"Resource Not Found","status":"404"}],"meta":{"example":"meta in response"}}`
-}
-
-// getMultiErrorResponseMultiErrorsWithMetaBody returns test error response body for getMultiErrors function with meta-data
-func getMultiErrorResponseMultiErrorsWithMetaBody() string {
-	return `{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}],"meta":{"example":"meta in response"}}`
-}
-
-// getTestUser returns user used by tests
-func getTestUser() user {
-	return user{
-		ID:   "some-id",
-		Name: "john doe",
-	}
-}
-
-// getReplyFormattedHeader returns header in expected format for reply library
-func getReplyFormattedHeader() map[string]string {
-	return map[string]string{"correlation-id": "some-id"}
-}
-
-// getReplyFormattedMeta returns meta-data in expected format for reply library
-func getReplyFormattedMeta() map[string]interface{} {
-	return map[string]interface{}{
-		"example": "meta in response",
-	}
 }
 
 func TestReplier_NewHTTPResponse(t *testing.T) {
@@ -1203,30 +1062,95 @@ func TestReplier_NewHTTPTokenResponseAide(t *testing.T) {
 	}
 }
 
-func TestReplier_AideNewHTTPBlankResponse(t *testing.T) {
+func TestReplier_NewHTTPBlankResponseAide(t *testing.T) {
 
 	tests := []struct {
 		name               string
 		manifests          []reply.ErrorManifest
-		StatusCode         int
+		passedStatusCode   int
+		responseAttributes []reply.ResponseAttributes
+		transferObject     reply.TransferObject
+		transferObjecError reply.TransferObjectError
 		assertResponse     func(w *httptest.ResponseRecorder, t *testing.T)
 		expectedStatusCode int
 	}{
 		{
-			name:               "Success",
-			manifests:          []reply.ErrorManifest{},
-			StatusCode:         201,
-			expectedStatusCode: http.StatusCreated,
+			name:               "Success - Blank response (default)",
+			manifests:          getEmptyErrorManifest(),
+			expectedStatusCode: http.StatusOK,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
-				response := baseTestResponse{}
+				returnedBody := w.Body.String()
 
-				err := unmarshalResponseBody(w, &response)
-				if err != nil {
-					t.Fatalf("cannot get response content: %v", err)
-				}
+				assert.Equal(t, stringWithNewLine(getBlankResponseBody()), returnedBody)
 
-				assert.Equal(t, baseTestResponse{Data: "{}"}, response)
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Blank response with different status code",
+			manifests:          getEmptyErrorManifest(),
+			passedStatusCode:   302,
+			expectedStatusCode: 302,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getBlankResponseBody()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:             "Success - Blank response with Additional Headers",
+			manifests:        getEmptyErrorManifest(),
+			passedStatusCode: 302,
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: 302,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getBlankResponseBody()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:             "Success - Blank response with Meta-Information",
+			manifests:        getEmptyErrorManifest(),
+			passedStatusCode: 302,
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+			},
+			expectedStatusCode: 302,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getBlankResponseWithMetaBody()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:             "Success - Blank response with Meta-Information & Additional Header",
+			manifests:        getEmptyErrorManifest(),
+			passedStatusCode: 302,
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: 302,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getBlankResponseWithMetaBody()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
 		},
 	}
@@ -1236,9 +1160,24 @@ func TestReplier_AideNewHTTPBlankResponse(t *testing.T) {
 
 			w := httptest.NewRecorder()
 
-			replier := reply.NewReplier(test.manifests)
+			var replier *reply.Replier
 
-			replier.NewHTTPBlankResponse(w, test.StatusCode)
+			switch {
+			case test.transferObject != nil && test.transferObjecError != nil:
+				replier = reply.NewReplier(test.manifests, reply.WithTransferObject(test.transferObject), reply.WithTransferObjectError(test.transferObjecError))
+			case test.transferObject != nil && test.transferObjecError == nil:
+				replier = reply.NewReplier(test.manifests, reply.WithTransferObject(test.transferObject))
+			case test.transferObject == nil && test.transferObjecError != nil:
+				replier = reply.NewReplier(test.manifests, reply.WithTransferObjectError(test.transferObjecError))
+			case test.transferObject == nil && test.transferObjecError == nil:
+				replier = reply.NewReplier(test.manifests)
+			}
+
+			if len(test.responseAttributes) > 0 {
+				replier.NewHTTPBlankResponse(w, test.passedStatusCode, test.responseAttributes...)
+			} else {
+				replier.NewHTTPBlankResponse(w, test.passedStatusCode)
+			}
 
 			assert.Equal(t, test.expectedStatusCode, w.Code)
 			test.assertResponse(w, t)
@@ -1246,17 +1185,130 @@ func TestReplier_AideNewHTTPBlankResponse(t *testing.T) {
 	}
 }
 
-// unmarshalResponseBody handles unmarshalling recorder's response to specified
-// response body
-func unmarshalResponseBody(w *httptest.ResponseRecorder, responseBody interface{}) error {
-	content, err := ioutil.ReadAll(w.Result().Body)
-	if err != nil {
-		return err
-	}
+// stringWithNewLine appends new line to passed string
+func stringWithNewLine(s string) string {
+	return fmt.Sprintf("%s\n", s)
+}
 
-	if err = json.Unmarshal(content, responseBody); err != nil {
-		return err
-	}
+// getDefaultHeader returns default headers
+func getDefaultHeader() http.Header {
+	return http.Header{"Content-Type": []string{"application/json"}}
+}
 
-	return nil
+// getAdditionalHeaders returns default header with addition correlation ID header
+func getAdditionalHeaders() http.Header {
+	return http.Header{"Content-Type": []string{"application/json"}, "Correlation-Id": []string{"some-id"}}
+}
+
+// getEmptyErrorManifest returns an empty manifest
+func getEmptyErrorManifest() []reply.ErrorManifest {
+	return []reply.ErrorManifest{}
+}
+
+// getDefaultErrorManifest returns the default manifest
+func getDefaultErrorManifest() []reply.ErrorManifest {
+	return []reply.ErrorManifest{
+		{"example-404-error": reply.ErrorManifestItem{Title: "Resource Not Found", StatusCode: http.StatusNotFound}},
+		{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
+		{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
+	}
+}
+
+// getMultiErrors returns example errors
+func getMultiErrors() []error {
+	return []error{
+		errors.New("example-dob-validation-error"),
+		errors.New("example-name-validation-error"),
+	}
+}
+
+// getMultiErrorsWithMissingErr returns example errors with one error
+// that does not exist in manifest
+func getMultiErrorsWithMissingErr() []error {
+	return append(getMultiErrors(), errors.New("example-missing-error"))
+}
+
+// getExampleErrorOne returns example error (1)
+func getExampleErrorOne() error {
+	return errors.New("example-404-error")
+}
+
+// getBlankResponseBody returns default blank response body
+func getBlankResponseBody() string {
+	return `{"data":"{}"}`
+}
+
+// getBlankResponseWithMetaBody returns default blank response body with meta-data
+func getBlankResponseWithMetaBody() string {
+	return `{"data":"{}","meta":{"example":"meta in response"}}`
+}
+
+// getDataResponseBody returns test data response body
+func getDataResponseBody() string {
+	return `{"data":{"id":"some-id","name":"john doe"}}`
+}
+
+// getDataResponseWithMetaBody returns test data response body with meta-data
+func getDataResponseWithMetaBody() string {
+	return `{"data":{"id":"some-id","name":"john doe"},"meta":{"example":"meta in response"}}`
+}
+
+// getFullTokenResponseBody returns test full token response body
+func getFullTokenResponseBody() string {
+	return `{"access_token":"test-token-1","refresh_token":"test-token-2"}`
+}
+
+// getSingleTokenResponseBody returns test single token response body
+func getSingleTokenResponseBody() string {
+	return `{"access_token":"test-token-1"}`
+}
+
+// getFullTokenResponseWithMetaBody returns test  full token response body with meta-data
+func getFullTokenResponseWithMetaBody() string {
+	return `{"access_token":"test-token-1","refresh_token":"test-token-2","meta":{"example":"meta in response"}}`
+}
+
+// getErrorResponseBody returns internal server error response body
+func getErrorResponseISEBody() string {
+	return `{"errors":[{"title":"Internal Server Error","status":"500"}]}`
+}
+
+// getErrorResponseForExampleErrorOne returns test error response body for getErrorResponseForExampleErrorOne function
+func getErrorResponseForExampleErrorOne() string {
+	return `{"errors":[{"title":"Resource Not Found","status":"404"}]}`
+}
+
+// getMultiErrorResponseMultiErrors returns test error response body for getMultiErrors function
+func getMultiErrorResponseMultiErrors() string {
+	return `{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}]}`
+}
+
+// getErrorResponseForExampleErrorOneWithMetaBody returns test error response body for getErrorResponseForExampleErrorOne function with meta-data
+func getErrorResponseForExampleErrorOneWithMetaBody() string {
+	return `{"errors":[{"title":"Resource Not Found","status":"404"}],"meta":{"example":"meta in response"}}`
+}
+
+// getMultiErrorResponseMultiErrorsWithMetaBody returns test error response body for getMultiErrors function with meta-data
+func getMultiErrorResponseMultiErrorsWithMetaBody() string {
+	return `{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}],"meta":{"example":"meta in response"}}`
+}
+
+// getTestUser returns user used by tests
+func getTestUser() user {
+	return user{
+		ID:   "some-id",
+		Name: "john doe",
+	}
+}
+
+// getReplyFormattedHeader returns header in expected format for reply library
+func getReplyFormattedHeader() map[string]string {
+	return map[string]string{"correlation-id": "some-id"}
+}
+
+// getReplyFormattedMeta returns meta-data in expected format for reply library
+func getReplyFormattedMeta() map[string]interface{} {
+	return map[string]interface{}{
+		"example": "meta in response",
+	}
 }

--- a/replier_test.go
+++ b/replier_test.go
@@ -102,6 +102,46 @@ func getDataResponseWithMetaBody() string {
 	return `{"data":{"id":"some-id","name":"john doe"},"meta":{"example":"meta in response"}}`
 }
 
+// getFullTokenResponseBody returns test full token response body
+func getFullTokenResponseBody() string {
+	return `{"access_token":"test-token-1","refresh_token":"test-token-2"}`
+}
+
+// getSingleTokenResponseBody returns test single token response body
+func getSingleTokenResponseBody() string {
+	return `{"access_token":"test-token-1"}`
+}
+
+// getFullTokenResponseWithMetaBody returns test  full token response body with meta-data
+func getFullTokenResponseWithMetaBody() string {
+	return `{"access_token":"test-token-1","refresh_token":"test-token-2","meta":{"example":"meta in response"}}`
+}
+
+// getErrorResponseBody returns internal server error response body
+func getErrorResponseISEBody() string {
+	return `{"errors":[{"title":"Internal Server Error","status":"500"}]}`
+}
+
+// getErrorResponseForExampleErrorOne returns test error response body for getErrorResponseForExampleErrorOne function
+func getErrorResponseForExampleErrorOne() string {
+	return `{"errors":[{"title":"Resource Not Found","status":"404"}]}`
+}
+
+// getMultiErrorResponseMultiErrors returns test error response body for getMultiErrors function
+func getMultiErrorResponseMultiErrors() string {
+	return `{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}]}`
+}
+
+// getErrorResponseForExampleErrorOneWithMetaBody returns test error response body for getErrorResponseForExampleErrorOne function with meta-data
+func getErrorResponseForExampleErrorOneWithMetaBody() string {
+	return `{"errors":[{"title":"Resource Not Found","status":"404"}],"meta":{"example":"meta in response"}}`
+}
+
+// getMultiErrorResponseMultiErrorsWithMetaBody returns test error response body for getMultiErrors function with meta-data
+func getMultiErrorResponseMultiErrorsWithMetaBody() string {
+	return `{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}],"meta":{"example":"meta in response"}}`
+}
+
 // getTestUser returns user used by tests
 func getTestUser() user {
 	return user{
@@ -306,7 +346,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1","refresh_token":"test-token-2"}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getFullTokenResponseBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -323,7 +363,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1"}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getSingleTokenResponseBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -342,7 +382,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1","refresh_token":"test-token-2"}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getFullTokenResponseBody()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -361,7 +401,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1","refresh_token":"test-token-2","meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getFullTokenResponseWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -381,7 +421,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1","refresh_token":"test-token-2","meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getFullTokenResponseWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -399,7 +439,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Internal Server Error","status":"500"}]}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getErrorResponseISEBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -415,7 +455,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}]}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOne()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -431,7 +471,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}]}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrors()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -447,7 +487,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Internal Server Error","status":"500"}]}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getErrorResponseISEBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -464,7 +504,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}]}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOne()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -481,7 +521,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}]}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrors()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -498,7 +538,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}],"meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -515,7 +555,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}],"meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -533,7 +573,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}],"meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -551,7 +591,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}],"meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -572,7 +612,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}]}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrors()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -590,7 +630,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}]}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOne()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},

--- a/replier_test.go
+++ b/replier_test.go
@@ -88,6 +88,8 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 		name               string
 		manifests          []reply.ErrorManifest
 		request            reply.NewResponseRequest
+		transferObject     reply.TransferObject
+		transferObjecError reply.TransferObjectError
 		assertResponse     func(w *httptest.ResponseRecorder, t *testing.T)
 		expectedStatusCode int
 	}{
@@ -634,7 +636,18 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 			w := httptest.NewRecorder()
 
-			replier := reply.NewReplier(test.manifests)
+			var replier *reply.Replier
+
+			switch {
+			case test.transferObject != nil && test.transferObjecError != nil:
+				replier = reply.NewReplier(test.manifests, reply.WithTransferObject(test.transferObject), reply.WithTransferObjectError(test.transferObjecError))
+			case test.transferObject != nil && test.transferObjecError == nil:
+				replier = reply.NewReplier(test.manifests, reply.WithTransferObject(test.transferObject))
+			case test.transferObject == nil && test.transferObjecError != nil:
+				replier = reply.NewReplier(test.manifests, reply.WithTransferObjectError(test.transferObjecError))
+			case test.transferObject == nil && test.transferObjecError == nil:
+				replier = reply.NewReplier(test.manifests)
+			}
 
 			test.request.Writer = w
 

--- a/replier_test.go
+++ b/replier_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/ooaklee/reply"
@@ -645,6 +646,185 @@ func TestReplier_NewHTTPErrorResponseAide(t *testing.T) {
 				returnedBody := w.Body.String()
 
 				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneWithMetaBody()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		///////////////////////////////
+		/////// With Custom TOE ///////
+		{
+			name:               "Failure - Error response (Using custom TOE)",
+			manifests:          getEmptyErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			expectedStatusCode: http.StatusInternalServerError,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseISEBodyUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Error response (Using custom TOE)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Error response with Additional Headers (Using custom TOE)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Error response with Meta-Information (Using custom TOE)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+			},
+			expectedStatusCode: 404,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneWithMetaBodyUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Error response with Meta-Information & Additional Header (Using custom TOE)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneWithMetaBodyUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		///////////////////////////////
+		///// With Custom TOE & TO ////
+		{
+			name:               "Failure - Error response (Using custom TOE & TO)",
+			manifests:          getEmptyErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			expectedStatusCode: http.StatusInternalServerError,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseISEBodyUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Error response (Using custom TOE & TO)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Error response with Additional Headers (Using custom TOE & TO)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Error response with Meta-Information (Using custom TOE & TO)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+			},
+			expectedStatusCode: 404,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneWithMetaBodyUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Error response with Meta-Information & Additional Header (Using custom TOE & TO)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getExampleErrorOne(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneWithMetaBodyUsingCustomTOEAndTO()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -1293,6 +1473,72 @@ func getMultiErrorResponseMultiErrorsWithMetaBody() string {
 	return `{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}],"meta":{"example":"meta in response"}}`
 }
 
+////////////////////////
+//// For custom TOE ////
+
+// getErrorResponseBodyUsingCustomTOE returns internal server error response body
+// based on custom Transfer Object Error
+func getErrorResponseISEBodyUsingCustomTOE() string {
+	return `{"errors":[{"title":"Internal Server Error","more":{"status":"500"}}]}`
+}
+
+// getErrorResponseForExampleErrorOneUsingCustomTOE returns test error response body for getErrorResponseForExampleErrorOne function
+// based on custom Transfer Object Error
+func getErrorResponseForExampleErrorOneUsingCustomTOE() string {
+	return `{"errors":[{"title":"Resource Not Found","more":{"status":"404"}}]}`
+}
+
+// getMultiErrorResponseMultiErrorsUsingCustomTOE returns test error response body for getMultiErrors function
+// based on custom Transfer Object Error
+func getMultiErrorResponseMultiErrorsUsingCustomTOE() string {
+	return `{"errors":[{"title":"Validation Error","message":"Check your DoB, and try again.","more":{"status":"400","code":"100YT"}},{"title":"Validation Error","message":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","more":{"status":"400","code":"1011"}}]}`
+}
+
+// getErrorResponseForExampleErrorOneWithMetaBodyUsingCustomTOE returns test error response body for getErrorResponseForExampleErrorOne function with meta-data
+// based on custom Transfer Object Error
+func getErrorResponseForExampleErrorOneWithMetaBodyUsingCustomTOE() string {
+	return `{"errors":[{"title":"Resource Not Found","more":{"status":"404"}}],"meta":{"example":"meta in response"}}`
+}
+
+// getMultiErrorResponseMultiErrorsWithMetaBodyUsingCustomTOE returns test error response body for getMultiErrors function with meta-data
+// based on custom Transfer Object Error
+func getMultiErrorResponseMultiErrorsWithMetaBodyUsingCustomTOE() string {
+	return `{"errors":[{"title":"Validation Error","message":"Check your DoB, and try again.","more":{"status":"400","code":"100YT"}},{"title":"Validation Error","message":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","more":{"status":"400","code":"1011"}}],"meta":{"example":"meta in response"}}`
+}
+
+////////////////////////
+// For custom TOE & TO /
+
+// getErrorResponseBodyUsingCustomTOEAndTO returns internal server error response body
+// based on custom Transfer Object Error & Transfer Object
+func getErrorResponseISEBodyUsingCustomTOEAndTO() string {
+	return `{"bar":{"errors":[{"title":"Internal Server Error","more":{"status":"500"}}]}}`
+}
+
+// getErrorResponseForExampleErrorOneUsingCustomTOEAndTO returns test error response body for getErrorResponseForExampleErrorOne function
+// based on custom Transfer Object Error & Transfer Object
+func getErrorResponseForExampleErrorOneUsingCustomTOEAndTO() string {
+	return `{"bar":{"errors":[{"title":"Resource Not Found","more":{"status":"404"}}]}}`
+}
+
+// getMultiErrorResponseMultiErrorsUsingCustomTOEAndTO returns test error response body for getMultiErrors function
+// based on custom Transfer Object Error & Transfer Object
+func getMultiErrorResponseMultiErrorsUsingCustomTOEAndTO() string {
+	return `{"bar":{"errors":[{"title":"Validation Error","message":"Check your DoB, and try again.","more":{"status":"400","code":"100YT"}},{"title":"Validation Error","message":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","more":{"status":"400","code":"1011"}}]}}`
+}
+
+// getErrorResponseForExampleErrorOneWithMetaBodyUsingCustomTOEAndTO returns test error response body for getErrorResponseForExampleErrorOne function with meta-data
+// based on custom Transfer Object Error & Transfer Object
+func getErrorResponseForExampleErrorOneWithMetaBodyUsingCustomTOEAndTO() string {
+	return `{"bar":{"errors":[{"title":"Resource Not Found","more":{"status":"404"}}],"meta":{"example":"meta in response"}}}`
+}
+
+// getMultiErrorResponseMultiErrorsWithMetaBodyUsingCustomTOEAndTO returns test error response body for getMultiErrors function with meta-data
+// based on custom Transfer Object Error & Transfer Object
+func getMultiErrorResponseMultiErrorsWithMetaBodyUsingCustomTOEAndTO() string {
+	return `{"bar":{"errors":[{"title":"Validation Error","message":"Check your DoB, and try again.","more":{"status":"400","code":"100YT"}},{"title":"Validation Error","message":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","more":{"status":"400","code":"1011"}}],"meta":{"example":"meta in response"}}}`
+}
+
 // getTestUser returns user used by tests
 func getTestUser() user {
 	return user{
@@ -1312,3 +1558,172 @@ func getReplyFormattedMeta() map[string]interface{} {
 		"example": "meta in response",
 	}
 }
+
+/////////////////////////////////////////////////
+/////// Custom Transition Object Example ////////
+// This is an example of how you can create a
+// custom response structure based on your
+// requirements.
+//
+// Sourced from `examples/example_simple_api.go`
+type fooReplyTransferObject struct {
+	HTTPWriter http.ResponseWriter `json:"-"`
+	Headers    map[string]string   `json:"-"`
+	StatusCode int                 `json:"-"`
+	Bar        barEmbeddedExample  `json:"bar,omitempty"`
+}
+
+type barEmbeddedExample struct {
+	Errors       []reply.TransferObjectError `json:"errors,omitempty"`
+	Meta         map[string]interface{}      `json:"meta,omitempty"`
+	Data         interface{}                 `json:"data,omitempty"`
+	AccessToken  string                      `json:"access_token,omitempty"`
+	RefreshToken string                      `json:"refresh_token,omitempty"`
+}
+
+func (t *fooReplyTransferObject) SetHeaders(headers map[string]string) {
+	t.Headers = headers
+}
+
+func (t *fooReplyTransferObject) SetStatusCode(code int) {
+	t.StatusCode = code
+}
+
+func (t *fooReplyTransferObject) SetMeta(meta map[string]interface{}) {
+	t.Bar.Meta = meta
+}
+
+func (t *fooReplyTransferObject) SetWriter(writer http.ResponseWriter) {
+	t.HTTPWriter = writer
+}
+
+func (t *fooReplyTransferObject) SetTokenOne(token string) {
+	t.Bar.AccessToken = token
+}
+
+func (t *fooReplyTransferObject) SetTokenTwo(token string) {
+	t.Bar.RefreshToken = token
+}
+
+func (t *fooReplyTransferObject) GetWriter() http.ResponseWriter {
+	return t.HTTPWriter
+}
+
+func (t *fooReplyTransferObject) GetStatusCode() int {
+	return t.StatusCode
+}
+
+func (t *fooReplyTransferObject) SetData(data interface{}) {
+	t.Bar.Data = data
+}
+
+func (t *fooReplyTransferObject) RefreshTransferObject() reply.TransferObject {
+	return &fooReplyTransferObject{}
+}
+
+func (t *fooReplyTransferObject) SetErrors(transferObjectErrors []reply.TransferObjectError) {
+	t.Bar.Errors = transferObjectErrors
+}
+
+////////////////////
+
+/////////////////////////////////////////////////
+//// Custom Transition Object Error Example /////
+// This is an example of how you can create a
+// custom response structure for errrors retutned
+// in the response
+//
+// Sourced from `examples/example_simple_api.go`
+
+type barError struct {
+
+	// Title a short summary of the problem
+	Title string `json:"title,omitempty"`
+
+	// Message a description of the error
+	Message string `json:"message,omitempty"`
+
+	// About holds the link that gives further insight into the error
+	About string `json:"about,omitempty"`
+
+	// More randomd top level attribute to make error
+	// difference
+	More struct {
+		// Status the HTTP status associated with error
+		Status string `json:"status,omitempty"`
+
+		// Code internal error code used to reference error
+		Code string `json:"code,omitempty"`
+
+		// Meta contains additional meta-information about the error
+		Meta interface{} `json:"meta,omitempty"`
+	} `json:"more,omitempty"`
+}
+
+// SetTitle adds title to error
+func (b *barError) SetTitle(title string) {
+	b.Title = title
+}
+
+// GetTitle returns error's title
+func (b *barError) GetTitle() string {
+	return b.Title
+}
+
+// SetDetail adds detail to error
+func (b *barError) SetDetail(detail string) {
+	b.Message = detail
+}
+
+// GetDetail return error's detail
+func (b *barError) GetDetail() string {
+	return b.Message
+}
+
+// SetAbout adds about to error
+func (b *barError) SetAbout(about string) {
+	b.About = about
+}
+
+// GetAbout return error's about
+func (b *barError) GetAbout() string {
+	return b.About
+}
+
+// SetStatusCode converts and add http status code to error
+func (b *barError) SetStatusCode(status int) {
+	b.More.Status = strconv.Itoa(status)
+}
+
+// GetStatusCode returns error's HTTP status code
+func (b *barError) GetStatusCode() string {
+	return b.More.Status
+}
+
+// SetCode adds internal code to error
+func (b *barError) SetCode(code string) {
+	b.More.Code = code
+}
+
+// GetCode returns error's internal code
+func (b *barError) GetCode() string {
+	return b.More.Code
+}
+
+// SetMeta adds meta property to error
+func (b *barError) SetMeta(meta interface{}) {
+	b.More.Meta = meta
+}
+
+// GetMeta returns error's meta property
+func (b *barError) GetMeta() interface{} {
+	return b.More.Meta
+}
+
+// RefreshTransferObject returns an empty instance of transfer object
+// error
+func (b *barError) RefreshTransferObject() reply.TransferObjectError {
+	return &barError{}
+}
+
+////////////////////

--- a/replier_test.go
+++ b/replier_test.go
@@ -82,6 +82,46 @@ func getExampleErrorOne() error {
 	return errors.New("example-404-error")
 }
 
+// getBlankResponseBody returns default blank response body
+func getBlankResponseBody() string {
+	return `{"data":"{}"}`
+}
+
+// getBlankResponseWithMetaBody returns default blank response body with meta-data
+func getBlankResponseWithMetaBody() string {
+	return `{"data":"{}","meta":{"example":"meta in response"}}`
+}
+
+// getDataResponseBody returns test data response body
+func getDataResponseBody() string {
+	return `{"data":{"id":"some-id","name":"john doe"}}`
+}
+
+// getDataResponseWithMetaBody returns test data response body with meta-data
+func getDataResponseWithMetaBody() string {
+	return `{"data":{"id":"some-id","name":"john doe"},"meta":{"example":"meta in response"}}`
+}
+
+// getTestUser returns user used by tests
+func getTestUser() user {
+	return user{
+		ID:   "some-id",
+		Name: "john doe",
+	}
+}
+
+// getReplyFormattedHeader returns header in expected format for reply library
+func getReplyFormattedHeader() map[string]string {
+	return map[string]string{"correlation-id": "some-id"}
+}
+
+// getReplyFormattedMeta returns meta-data in expected format for reply library
+func getReplyFormattedMeta() map[string]interface{} {
+	return map[string]interface{}{
+		"example": "meta in response",
+	}
+}
+
 func TestReplier_NewHTTPResponse(t *testing.T) {
 
 	tests := []struct {
@@ -104,7 +144,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":"{}"}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getBlankResponseBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -120,7 +160,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":"{}"}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getBlankResponseBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -130,14 +170,14 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getEmptyErrorManifest(),
 			request: reply.NewResponseRequest{
 				StatusCode: 302,
-				Headers:    map[string]string{"correlation-id": "some-id"},
+				Headers:    getReplyFormattedHeader(),
 			},
 			expectedStatusCode: 302,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":"{}"}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getBlankResponseBody()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -147,16 +187,14 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getEmptyErrorManifest(),
 			request: reply.NewResponseRequest{
 				StatusCode: 302,
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
+				Meta:       getReplyFormattedMeta(),
 			},
 			expectedStatusCode: 302,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":"{}","meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getBlankResponseWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -166,17 +204,15 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getEmptyErrorManifest(),
 			request: reply.NewResponseRequest{
 				StatusCode: 302,
-				Headers:    map[string]string{"correlation-id": "some-id"},
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
+				Headers:    getReplyFormattedHeader(),
+				Meta:       getReplyFormattedMeta(),
 			},
 			expectedStatusCode: 302,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":"{}","meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getBlankResponseWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -187,10 +223,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			name:      "Success - Data response",
 			manifests: getEmptyErrorManifest(),
 			request: reply.NewResponseRequest{
-				Data: user{
-					ID:   "some-id",
-					Name: "john doe",
-				},
+				Data:       getTestUser(),
 				StatusCode: 201,
 			},
 			expectedStatusCode: http.StatusCreated,
@@ -198,7 +231,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getDataResponseBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -207,19 +240,16 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			name:      "Success - Data response with Additional Headers",
 			manifests: getEmptyErrorManifest(),
 			request: reply.NewResponseRequest{
-				Data: user{
-					ID:   "some-id",
-					Name: "john doe",
-				},
+				Data:       getTestUser(),
 				StatusCode: 201,
-				Headers:    map[string]string{"correlation-id": "some-id"},
+				Headers:    getReplyFormattedHeader(),
 			},
 			expectedStatusCode: http.StatusCreated,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getDataResponseBody()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -229,20 +259,15 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getEmptyErrorManifest(),
 			request: reply.NewResponseRequest{
 				StatusCode: 201,
-				Data: user{
-					ID:   "some-id",
-					Name: "john doe",
-				},
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
+				Data:       getTestUser(),
+				Meta:       getReplyFormattedMeta(),
 			},
 			expectedStatusCode: 201,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"},"meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getDataResponseWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -252,21 +277,16 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getEmptyErrorManifest(),
 			request: reply.NewResponseRequest{
 				StatusCode: 201,
-				Headers:    map[string]string{"correlation-id": "some-id"},
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
-				Data: user{
-					ID:   "some-id",
-					Name: "john doe",
-				},
+				Headers:    getReplyFormattedHeader(),
+				Meta:       getReplyFormattedMeta(),
+				Data:       getTestUser(),
 			},
 			expectedStatusCode: 201,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"},"meta":{"example":"meta in response"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getDataResponseWithMetaBody()), returnedBody)
 
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
@@ -315,7 +335,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 				TokenOne:   "test-token-1",
 				TokenTwo:   "test-token-2",
 				StatusCode: 200,
-				Headers:    map[string]string{"correlation-id": "some-id"},
+				Headers:    getReplyFormattedHeader(),
 			},
 			expectedStatusCode: http.StatusOK,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
@@ -334,9 +354,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 				StatusCode: 200,
 				TokenOne:   "test-token-1",
 				TokenTwo:   "test-token-2",
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
+				Meta:       getReplyFormattedMeta(),
 			},
 			expectedStatusCode: 200,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
@@ -353,12 +371,10 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getEmptyErrorManifest(),
 			request: reply.NewResponseRequest{
 				StatusCode: 200,
-				Headers:    map[string]string{"correlation-id": "some-id"},
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
-				TokenOne: "test-token-1",
-				TokenTwo: "test-token-2",
+				Headers:    getReplyFormattedHeader(),
+				Meta:       getReplyFormattedMeta(),
+				TokenOne:   "test-token-1",
+				TokenTwo:   "test-token-2",
 			},
 			expectedStatusCode: 200,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
@@ -441,7 +457,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getDefaultErrorManifest(),
 			request: reply.NewResponseRequest{
 				Error:   getExampleErrorOne(),
-				Headers: map[string]string{"correlation-id": "some-id"},
+				Headers: getReplyFormattedHeader(),
 			},
 			expectedStatusCode: http.StatusNotFound,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
@@ -458,7 +474,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getDefaultErrorManifest(),
 			request: reply.NewResponseRequest{
 				Errors:  getMultiErrors(),
-				Headers: map[string]string{"correlation-id": "some-id"},
+				Headers: getReplyFormattedHeader(),
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
@@ -475,9 +491,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getDefaultErrorManifest(),
 			request: reply.NewResponseRequest{
 				Error: getExampleErrorOne(),
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
+				Meta:  getReplyFormattedMeta(),
 			},
 			expectedStatusCode: 404,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
@@ -494,9 +508,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getDefaultErrorManifest(),
 			request: reply.NewResponseRequest{
 				Errors: getMultiErrors(),
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
+				Meta:   getReplyFormattedMeta(),
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
@@ -513,10 +525,8 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getDefaultErrorManifest(),
 			request: reply.NewResponseRequest{
 				Error:   getExampleErrorOne(),
-				Headers: map[string]string{"correlation-id": "some-id"},
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
+				Headers: getReplyFormattedHeader(),
+				Meta:    getReplyFormattedMeta(),
 			},
 			expectedStatusCode: http.StatusNotFound,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
@@ -533,10 +543,8 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			manifests: getDefaultErrorManifest(),
 			request: reply.NewResponseRequest{
 				Errors:  getMultiErrors(),
-				Headers: map[string]string{"correlation-id": "some-id"},
-				Meta: map[string]interface{}{
-					"example": "meta in response",
-				},
+				Headers: getReplyFormattedHeader(),
+				Meta:    getReplyFormattedMeta(),
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
@@ -554,12 +562,9 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			name:      "Success - Multi Error response should take precedence",
 			manifests: getDefaultErrorManifest(),
 			request: reply.NewResponseRequest{
-				Errors: getMultiErrors(),
-				Error:  getExampleErrorOne(),
-				Data: user{
-					ID:   "some-id",
-					Name: "john doe",
-				},
+				Errors:     getMultiErrors(),
+				Error:      getExampleErrorOne(),
+				Data:       getTestUser(),
 				StatusCode: 201,
 			},
 			expectedStatusCode: http.StatusBadRequest,
@@ -576,11 +581,8 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			name:      "Success - Error response should take precedence",
 			manifests: getDefaultErrorManifest(),
 			request: reply.NewResponseRequest{
-				Error: getExampleErrorOne(),
-				Data: user{
-					ID:   "some-id",
-					Name: "john doe",
-				},
+				Error:      getExampleErrorOne(),
+				Data:       getTestUser(),
 				StatusCode: 201,
 			},
 			expectedStatusCode: http.StatusNotFound,
@@ -597,10 +599,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 			name:      "Success - Data response should take precedence",
 			manifests: getDefaultErrorManifest(),
 			request: reply.NewResponseRequest{
-				Data: user{
-					ID:   "some-id",
-					Name: "john doe",
-				},
+				Data:       getTestUser(),
 				StatusCode: 201,
 			},
 			expectedStatusCode: http.StatusCreated,
@@ -608,7 +607,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"}}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getDataResponseBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -624,7 +623,7 @@ func TestReplier_NewHTTPResponse(t *testing.T) {
 
 				returnedBody := w.Body.String()
 
-				assert.Equal(t, stringWithNewLine(`{"data":"{}"}`), returnedBody)
+				assert.Equal(t, stringWithNewLine(getBlankResponseBody()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},

--- a/replier_test.go
+++ b/replier_test.go
@@ -956,6 +956,185 @@ func TestReplier_NewHTTPMultiErrorResponseAide(t *testing.T) {
 				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
 		},
+		///////////////////////////////
+		/////// With Custom TOE ///////
+		{
+			name:               "Failure - Multi Error response (Using custom TOE)",
+			manifests:          getEmptyErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			expectedStatusCode: http.StatusInternalServerError,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseISEBodyUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Multi Error response (Using custom TOE)",
+			manifests:          getDefaultErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Multi Error response with Additional Headers (Using custom TOE)",
+			manifests:          getDefaultErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Multi Error response with Meta-Information (Using custom TOE)",
+			manifests:          getDefaultErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+			},
+			expectedStatusCode: 400,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsWithMetaBodyUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Multi Error response with Meta-Information & Additional Header (Using custom TOE)",
+			manifests:          getDefaultErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsWithMetaBodyUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		///////////////////////////////
+		///// With Custom TOE & TO ////
+		{
+			name:               "Failure - Multi Error response (Using custom TOE & TO)",
+			manifests:          getEmptyErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			expectedStatusCode: http.StatusInternalServerError,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getErrorResponseISEBodyUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Multi Error response (Using custom TOE & TO)",
+			manifests:          getDefaultErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Multi Error response with Additional Headers (Using custom TOE & TO)",
+			manifests:          getDefaultErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Multi Error response with Meta-Information (Using custom TOE & TO)",
+			manifests:          getDefaultErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+			},
+			expectedStatusCode: 400,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsWithMetaBodyUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Multi Error response with Meta-Information & Additional Header (Using custom TOE & TO)",
+			manifests:          getDefaultErrorManifest(),
+			passedErrors:       getMultiErrors(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			responseAttributes: []reply.ResponseAttributes{
+				reply.WithMeta(getReplyFormattedMeta()),
+				reply.WithHeaders(getReplyFormattedHeader()),
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsWithMetaBodyUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/replier_test.go
+++ b/replier_test.go
@@ -7,6 +7,7 @@ package reply_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -28,203 +29,602 @@ type baseStatusMessageResponse struct {
 	} `json:"status,omitempty"`
 }
 
-func TestReplier_NewHTTPResponseForTokens(t *testing.T) {
+type user struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
 
-	tests := []struct {
-		name               string
-		manifests          []reply.ErrorManifest
-		accessToken        string
-		refreshToken       string
-		StatusCode         int
-		assertResponse     func(w *httptest.ResponseRecorder, t *testing.T)
-		expectedStatusCode int
-	}{
-		{
-			name:               "Success - Access Token response",
-			manifests:          []reply.ErrorManifest{},
-			accessToken:        "test-access-token",
-			StatusCode:         200,
-			expectedStatusCode: http.StatusOK,
-			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+// stringWithNewLine appends new line to passed string
+func stringWithNewLine(s string) string {
+	return fmt.Sprintf("%s\n", s)
+}
 
-				response := baseTestResponse{}
+// getDefaultHeader returns default headers
+func getDefaultHeader() http.Header {
+	return http.Header{"Content-Type": []string{"application/json"}}
+}
 
-				err := unmarshalResponseBody(w, &response)
-				if err != nil {
-					t.Fatalf("cannot get response content: %v", err)
-				}
+// getAdditionalHeaders returns default header with addition correlation ID header
+func getAdditionalHeaders() http.Header {
+	return http.Header{"Content-Type": []string{"application/json"}, "Correlation-Id": []string{"some-id"}}
+}
 
-				assert.Equal(t, baseTestResponse{AccessToken: "test-access-token"}, response)
-			},
-		},
-		{
-			name:               "Success - Full Token response",
-			manifests:          []reply.ErrorManifest{},
-			accessToken:        "test-access-token",
-			refreshToken:       "test-refresh-token",
-			StatusCode:         200,
-			expectedStatusCode: http.StatusOK,
-			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+// getEmptyErrorManifest returns an empty manifest
+func getEmptyErrorManifest() []reply.ErrorManifest {
+	return []reply.ErrorManifest{}
+}
 
-				response := baseTestResponse{}
-
-				err := unmarshalResponseBody(w, &response)
-				if err != nil {
-					t.Fatalf("cannot get response content: %v", err)
-				}
-
-				assert.Equal(t, baseTestResponse{AccessToken: "test-access-token", RefreshToken: "test-refresh-token"}, response)
-			},
-		},
-		{
-			name:               "Failed - Default response sent",
-			manifests:          []reply.ErrorManifest{},
-			expectedStatusCode: 200,
-			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
-
-				response := baseTestResponse{}
-
-				err := unmarshalResponseBody(w, &response)
-				if err != nil {
-					t.Fatalf("cannot get response content: %v", err)
-				}
-
-				expectedResponse := baseTestResponse{Data: "{}"}
-
-				assert.Equal(t, expectedResponse, response)
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-
-			w := httptest.NewRecorder()
-
-			replier := reply.NewReplier(test.manifests)
-
-			replier.NewHTTPResponse(&reply.NewResponseRequest{
-				Writer:     w,
-				StatusCode: test.StatusCode,
-				TokenOne:   test.accessToken,
-				TokenTwo:   test.refreshToken,
-			})
-
-			assert.Equal(t, test.expectedStatusCode, w.Code)
-			test.assertResponse(w, t)
-		})
+// getDefaultErrorManifest returns the default manifest
+func getDefaultErrorManifest() []reply.ErrorManifest {
+	return []reply.ErrorManifest{
+		{"example-404-error": reply.ErrorManifestItem{Title: "Resource Not Found", StatusCode: http.StatusNotFound}},
+		{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
+		{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
 	}
 }
 
-func TestReplier_NewHTTPResponseForData(t *testing.T) {
-
-	type user struct {
-		ID   string `json:"id,omitempty"`
-		Name string `json:"name,omitempty"`
+// getMultiErrors returns example errors
+func getMultiErrors() []error {
+	return []error{
+		errors.New("example-dob-validation-error"),
+		errors.New("example-name-validation-error"),
 	}
+}
+
+// getMultiErrorsWithMissingErr returns example errors with one error
+// that does not exist in manifest
+func getMultiErrorsWithMissingErr() []error {
+	return append(getMultiErrors(), errors.New("example-missing-error"))
+}
+
+// getExampleErrorOne returns example error (1)
+func getExampleErrorOne() error {
+	return errors.New("example-404-error")
+}
+
+func TestReplier_NewHTTPResponse(t *testing.T) {
 
 	tests := []struct {
 		name               string
 		manifests          []reply.ErrorManifest
-		data               interface{}
-		StatusCode         int
+		request            reply.NewResponseRequest
 		assertResponse     func(w *httptest.ResponseRecorder, t *testing.T)
 		expectedStatusCode int
 	}{
+		///////////////////////////////
+		/////// Blank Response ////////
 		{
-			name:       "Success - Created Mock user",
-			manifests:  []reply.ErrorManifest{},
-			StatusCode: 201,
-			data: user{
-				ID:   "new-uuid",
-				Name: "Test User",
+			name:               "Success - Blank response (default)",
+			manifests:          getEmptyErrorManifest(),
+			request:            reply.NewResponseRequest{},
+			expectedStatusCode: http.StatusOK,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"data":"{}"}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Blank response with different status code",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				StatusCode: 302,
+			},
+			expectedStatusCode: 302,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"data":"{}"}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Blank response with Additional Headers",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				StatusCode: 302,
+				Headers:    map[string]string{"correlation-id": "some-id"},
+			},
+			expectedStatusCode: 302,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"data":"{}"}`), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Blank response with Meta-Information",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				StatusCode: 302,
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+			},
+			expectedStatusCode: 302,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"data":"{}","meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Blank response with Meta-Information & Additional Header",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				StatusCode: 302,
+				Headers:    map[string]string{"correlation-id": "some-id"},
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+			},
+			expectedStatusCode: 302,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"data":"{}","meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		///////////////////////////////
+		//////// Data Response ////////
+		{
+			name:      "Success - Data response",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				Data: user{
+					ID:   "some-id",
+					Name: "john doe",
+				},
+				StatusCode: 201,
 			},
 			expectedStatusCode: http.StatusCreated,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
-				response := baseTestResponse{}
+				returnedBody := w.Body.String()
 
-				err := unmarshalResponseBody(w, &response)
-				if err != nil {
-					t.Fatalf("cannot get response content: %v", err)
-				}
+				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"}}`), returnedBody)
 
-				assert.Equal(t, baseTestResponse{Data: map[string]interface{}{"id": "new-uuid", "name": "Test User"}}, response)
+				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
 		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-
-			w := httptest.NewRecorder()
-
-			replier := reply.NewReplier(test.manifests)
-
-			replier.NewHTTPResponse(&reply.NewResponseRequest{
-				Writer:     w,
-				StatusCode: test.StatusCode,
-				Data:       test.data,
-			})
-
-			assert.Equal(t, test.expectedStatusCode, w.Code)
-			test.assertResponse(w, t)
-		})
-	}
-}
-
-func TestReplier_NewHTTPResponseForError(t *testing.T) {
-
-	tests := []struct {
-		name               string
-		manifests          []reply.ErrorManifest
-		err                error
-		StatusCode         int
-		assertResponse     func(w *httptest.ResponseRecorder, t *testing.T)
-		expectedStatusCode int
-	}{
 		{
-			name: "Success - Resource not found",
-			manifests: append([]reply.ErrorManifest{
-				{"test-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
-			},
-				reply.ErrorManifest{
-					"test-401-error": reply.ErrorManifestItem{Title: "unauthorized", StatusCode: http.StatusUnauthorized},
+			name:      "Success - Data response with Additional Headers",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				Data: user{
+					ID:   "some-id",
+					Name: "john doe",
 				},
-			),
-			err:                errors.New("test-404-error"),
-			expectedStatusCode: http.StatusNotFound,
+				StatusCode: 201,
+				Headers:    map[string]string{"correlation-id": "some-id"},
+			},
+			expectedStatusCode: http.StatusCreated,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
-				response := baseStatusMessageResponse{}
+				returnedBody := w.Body.String()
 
-				err := unmarshalResponseBody(w, &response)
-				if err != nil {
-					t.Fatalf("cannot get response content: %v", err)
-				}
+				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"}}`), returnedBody)
 
-				expectedResponse := baseStatusMessageResponse{}
-				expectedResponse.Status.Message = "resource not found"
-				assert.Equal(t, expectedResponse, response)
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
 			},
 		},
 		{
-			name:               "Failure - Error not in manifest",
-			manifests:          []reply.ErrorManifest{},
-			err:                errors.New("test-404-error"),
+			name:      "Success - Data response with Meta-Information",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				StatusCode: 201,
+				Data: user{
+					ID:   "some-id",
+					Name: "john doe",
+				},
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+			},
+			expectedStatusCode: 201,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"},"meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Data response with Meta-Information & Additional Header",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				StatusCode: 201,
+				Headers:    map[string]string{"correlation-id": "some-id"},
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+				Data: user{
+					ID:   "some-id",
+					Name: "john doe",
+				},
+			},
+			expectedStatusCode: 201,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"},"meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		///////////////////////////////
+		/////// Token Response ////////
+		{
+			name:      "Success - Token response",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				TokenOne:   "test-token-1",
+				TokenTwo:   "test-token-2",
+				StatusCode: 200,
+			},
+			expectedStatusCode: http.StatusOK,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1","refresh_token":"test-token-2"}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Token response (single token)",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				TokenOne:   "test-token-1",
+				StatusCode: 200,
+			},
+			expectedStatusCode: http.StatusOK,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1"}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Data response with Additional Headers",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				TokenOne:   "test-token-1",
+				TokenTwo:   "test-token-2",
+				StatusCode: 200,
+				Headers:    map[string]string{"correlation-id": "some-id"},
+			},
+			expectedStatusCode: http.StatusOK,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1","refresh_token":"test-token-2"}`), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Data response with Meta-Information",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				StatusCode: 200,
+				TokenOne:   "test-token-1",
+				TokenTwo:   "test-token-2",
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+			},
+			expectedStatusCode: 200,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1","refresh_token":"test-token-2","meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Data response with Meta-Information & Additional Header",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				StatusCode: 200,
+				Headers:    map[string]string{"correlation-id": "some-id"},
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+				TokenOne: "test-token-1",
+				TokenTwo: "test-token-2",
+			},
+			expectedStatusCode: 200,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"access_token":"test-token-1","refresh_token":"test-token-2","meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		///////////////////////////////
+		/////// Error Response ////////
+		{
+			name:      "Failure - Error response",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				Error: getExampleErrorOne(),
+			},
 			expectedStatusCode: http.StatusInternalServerError,
 			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
 
-				response := baseStatusMessageResponse{}
+				returnedBody := w.Body.String()
 
-				err := unmarshalResponseBody(w, &response)
-				if err != nil {
-					t.Fatalf("cannot get response content: %v", err)
-				}
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Internal Server Error","status":"500"}]}`), returnedBody)
 
-				expectedResponse := baseStatusMessageResponse{}
-				expectedResponse.Status.Message = "Internal Server Error"
-				assert.Equal(t, expectedResponse, response)
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Error response",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Error: getExampleErrorOne(),
+			},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}]}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Multi Error response",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Errors: getMultiErrors(),
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}]}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Failure -  Multi Error response missing error",
+			manifests: getEmptyErrorManifest(),
+			request: reply.NewResponseRequest{
+				Errors: getMultiErrorsWithMissingErr(),
+			},
+			expectedStatusCode: http.StatusInternalServerError,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Internal Server Error","status":"500"}]}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Error response with Additional Headers",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Error:   getExampleErrorOne(),
+				Headers: map[string]string{"correlation-id": "some-id"},
+			},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}]}`), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Multi error response with Additional Headers",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Errors:  getMultiErrors(),
+				Headers: map[string]string{"correlation-id": "some-id"},
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}]}`), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Error response with Meta-Information",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Error: getExampleErrorOne(),
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+			},
+			expectedStatusCode: 404,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}],"meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Multi error response with Meta-Information",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Errors: getMultiErrors(),
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}],"meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Error response with Meta-Information & Additional Header",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Error:   getExampleErrorOne(),
+				Headers: map[string]string{"correlation-id": "some-id"},
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+			},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}],"meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Multi error response with Meta-Information & Additional Header",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Errors:  getMultiErrors(),
+				Headers: map[string]string{"correlation-id": "some-id"},
+				Meta: map[string]interface{}{
+					"example": "meta in response",
+				},
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}],"meta":{"example":"meta in response"}}`), returnedBody)
+
+				assert.Equal(t, getAdditionalHeaders(), w.Header())
+			},
+		},
+		///////////////////////////////
+		////// Response Ranking ///////
+		{
+			name:      "Success - Multi Error response should take precedence",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Errors: getMultiErrors(),
+				Error:  getExampleErrorOne(),
+				Data: user{
+					ID:   "some-id",
+					Name: "john doe",
+				},
+				StatusCode: 201,
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Validation Error","detail":"Check your DoB, and try again.","status":"400","code":"100YT"},{"title":"Validation Error","detail":"The name provided does not meet validation requirements","about":"www.example.com/reply/validation/1011","status":"400","code":"1011"}]}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Error response should take precedence",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Error: getExampleErrorOne(),
+				Data: user{
+					ID:   "some-id",
+					Name: "john doe",
+				},
+				StatusCode: 201,
+			},
+			expectedStatusCode: http.StatusNotFound,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"errors":[{"title":"Resource Not Found","status":"404"}]}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Data response should take precedence",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				Data: user{
+					ID:   "some-id",
+					Name: "john doe",
+				},
+				StatusCode: 201,
+			},
+			expectedStatusCode: http.StatusCreated,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"data":{"id":"some-id","name":"john doe"}}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:      "Success - Default response should take precedence",
+			manifests: getDefaultErrorManifest(),
+			request: reply.NewResponseRequest{
+				StatusCode: 201,
+			},
+			expectedStatusCode: http.StatusCreated,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(`{"data":"{}"}`), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
 		},
 	}
@@ -236,10 +636,9 @@ func TestReplier_NewHTTPResponseForError(t *testing.T) {
 
 			replier := reply.NewReplier(test.manifests)
 
-			replier.NewHTTPResponse(&reply.NewResponseRequest{
-				Writer: w,
-				Error:  test.err,
-			})
+			test.request.Writer = w
+
+			replier.NewHTTPResponse(&test.request)
 
 			assert.Equal(t, test.expectedStatusCode, w.Code)
 			test.assertResponse(w, t)


### PR DESCRIPTION
## What has been done:
- Update top-level response members from `meta`, `status` and `data`  ->  `meta`, `errors` and `data`
- Rethink how errors are handled and represented in `default transfer object`, `*TransferObjectStatus`  -> `[]TransferObjectError`
- Expanded fields and methods on the `Error` object
- Added additional fields to `ErrorManifestItem` to match updated `Error` object.
- Created interface for a transfer object error
- Created function to convert `manifest error item` to `transfer object error`
- Updated code to make use of new models/interfaces
- Added new aide `NewHTTPMultiErrorResponse` to support multiple error response
  - Added logic to handle/ create multiple error response
- Updated `example simple api` to use the new aide `NewHTTPMultiErrorResponse`
- Refactored logic to allow users to pass custom error transfer objects (TransferObjectError), `reply.WithTransferObjectError`
  - Added `RefreshTransferObject` method call to `TransferObjectError`
- Updated `example simple api` to use the new Replier Option and update the `transfer object error`
- Refactor Token attributes & methods to have a more general name to make use of cases where API uses different token identifiers less confusing
  - `AccessToken` -> `TokenOne` & `RefreshToken` -> `TokenTwo`
    - Dev can create custom `TransferObject` to set JSON attribute to match their use case
- Added logic to set `StatusCode` if not set already. Defaults to `400`.
- Updated tests


## Checklist
- [X] Updated documentation (i.e., `README.md`)
- [X] Updated tests for added feature
- [X] Created pre-release(s) - `v1.0.0-alpha`, `v1.0.0-alpha.1`, `v1.0.0-alpha.2`, `v1.0.0-alpha.3`

## How to test:

- `go test -v ./...`