### PR TITLE
[REPLY-X] Update `NewHTTPErrorResponse` to support  error wrapping for multi-error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ And its respective error was passed when creating a new error response (`NewHTTP
 }
 ```
 
-If instead, multiple errors were passed to the `NewHTTPMultiErrorResponse` method, and all had an entry in the `ErrorManifest`, `reply` would return a response similar to the following JSON response:
+If instead, multiple errors were passed to the `NewHTTPMultiErrorResponse` method or errors keys were wrapped and passed to `NewHTTPErrorResponse`, and all had an entry in the `ErrorManifest`, `reply` would return a response similar to the following JSON response:
 
 
 ```json
@@ -161,6 +161,8 @@ Having expected `ErrorManifest` entries are especially important for `Multi Erro
 There are currently **3** Replier methods that make use of the `Error Manifest`. These methods are `NewHTTPResponse`, `NewHTTPMultiErrorResponse` and `NewHTTPErrorResponse`.
 
 > NOTE - `NewHTTPResponse` is the base of both the `NewHTTPMultiErrorResponse` and `NewHTTPErrorResponse` aides.
+>
+> NOTE - You can get `NewHTTPErrorResponse` to behave like `NewHTTPMultiErrorResponse` by wrapping your error keys with `errors.Join(errs...)`
 
 Below you will find an example using `NewHTTPResponse`. However, for simplicity, it's recommended you use one of the error aides. The error [aide implementation is outlined **HERE**](#error-response-type).
 
@@ -377,7 +379,9 @@ All core response types share universal attributes, which you can set in additio
 
 ### Error Response Type
 
-The `Error` response notifies the consumer when an error/ unexpected behaviour has occurred on the API. There are **2** types of `Error Response Types`, Individual (`NewHTTPErrorResponse`) and Multi (`NewHTTPMultiErrorResponse`).
+The `Error` response notifies the consumer when an error/ unexpected behaviour has occurred on the API. There are **2** types of `Error Response Types`, `NewHTTPErrorResponse` and `NewHTTPMultiErrorResponse`.
+
+> Where `NewHTTPMultiErrorResponse` explicitly expects a slice of errors, `NewHTTPErrorResponse` can also return multi errors response by wrapping the manifest key errors with `errors.Join(errs...)`.
 
 The error response object forwarded to the consumer is sourced from the [error manifest](#more-about-the-errormanifest). In the event the error's string
 representation isn't in the manifest; `reply` will return the consumer a "500 - Internal Server Error" response.
@@ -424,6 +428,22 @@ func ExampleHandler(w http.ResponseWriter, r *http.Request) {
   _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
     Writer: w,
     Errors: exampleErrs,
+  })
+}
+
+```
+
+You can also send a `multi error response` with a single error by wrapping the error keys with `errors.Join(errs...)`:
+
+```go
+func ExampleHandler(w http.ResponseWriter, r *http.Request) {
+
+  // errors returned
+  exampleWrappedErr := errors.Join(errors.New("example-name-validation-error"), errors.New("example-email-validation-error"))
+
+  _ = replier.NewHTTPResponse(&reply.NewResponseRequest{
+    Writer: w,
+    Error: exampleWrappedErr,
   })
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ooaklee/reply
 
-go 1.17
+go 1.20
 
 require github.com/stretchr/testify v1.7.0
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,13 @@
 # Reply Release Notes
 
+## [v1.1.0](https://github.com/ooaklee/reply/releases/tag/v1.1.0)
+2025-07-13
+
+* Updated `go.mod` to go 1.20
+* Updated `NewHTTPErrorResponse` to behave like `NewHTTPMultiErrorResponse` when manifest errors are wrapped, i.e. `errors.Join(errs...)`
+* Updated `README.md` to reflect the changes to `NewHTTPErrorResponse` and provide an example of how to use it with wrapped errors
+* Added a new test case to verify the changes
+
 ## [v1.0.0](https://github.com/ooaklee/reply/releases/tag/v1.0.0)
 2021-09-11
 

--- a/replier_test.go
+++ b/replier_test.go
@@ -599,6 +599,20 @@ func TestReplier_NewHTTPErrorResponseAide(t *testing.T) {
 			},
 		},
 		{
+			name:               "Success - Wrapped Error Response (Multi Error response)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getWrappedErrors(),
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrors()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
 			name:        "Success - Error response with Additional Headers",
 			manifests:   getDefaultErrorManifest(),
 			passedError: getExampleErrorOne(),
@@ -678,6 +692,21 @@ func TestReplier_NewHTTPErrorResponseAide(t *testing.T) {
 				returnedBody := w.Body.String()
 
 				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneUsingCustomTOE()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Wrapped Error Response (Multi Error response w/ Custom TOE)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getWrappedErrors(),
+			transferObjecError: &barError{},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsUsingCustomTOE()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -767,6 +796,22 @@ func TestReplier_NewHTTPErrorResponseAide(t *testing.T) {
 				returnedBody := w.Body.String()
 
 				assert.Equal(t, stringWithNewLine(getErrorResponseForExampleErrorOneUsingCustomTOEAndTO()), returnedBody)
+
+				assert.Equal(t, getDefaultHeader(), w.Header())
+			},
+		},
+		{
+			name:               "Success - Wrapped Error Response (Multi Error response w/ Custom TOE & TO)",
+			manifests:          getDefaultErrorManifest(),
+			passedError:        getWrappedErrors(),
+			transferObjecError: &barError{},
+			transferObject:     &fooReplyTransferObject{},
+			expectedStatusCode: http.StatusBadRequest,
+			assertResponse: func(w *httptest.ResponseRecorder, t *testing.T) {
+
+				returnedBody := w.Body.String()
+
+				assert.Equal(t, stringWithNewLine(getMultiErrorResponseMultiErrorsUsingCustomTOEAndTO()), returnedBody)
 
 				assert.Equal(t, getDefaultHeader(), w.Header())
 			},
@@ -1568,8 +1613,8 @@ func getEmptyErrorManifest() []reply.ErrorManifest {
 func getDefaultErrorManifest() []reply.ErrorManifest {
 	return []reply.ErrorManifest{
 		{"example-404-error": reply.ErrorManifestItem{Title: "Resource Not Found", StatusCode: http.StatusNotFound}},
-		{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
 		{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
+		{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
 	}
 }
 
@@ -1579,6 +1624,16 @@ func getMultiErrors() []error {
 		errors.New("example-dob-validation-error"),
 		errors.New("example-name-validation-error"),
 	}
+}
+
+// getWrappedErrors returns wrapped errors
+func getWrappedErrors() error {
+
+	err := errors.New("example-name-validation-error")
+	errTwo := errors.New("example-dob-validation-error")
+
+	return errors.Join(err, errTwo)
+
 }
 
 // getMultiErrorsWithMissingErr returns example errors with one error
@@ -1738,8 +1793,8 @@ func getReplyFormattedMeta() map[string]interface{} {
 	}
 }
 
-/////////////////////////////////////////////////
-/////// Custom Transition Object Example ////////
+// ///////////////////////////////////////////////
+// ///// Custom Transition Object Example ////////
 // This is an example of how you can create a
 // custom response structure based on your
 // requirements.


### PR DESCRIPTION
## What has been done:
- feat: Allow `NewHTTPErrorResponse` to return multi-error responses
- Updated `go.mod` to go 1.20
- Updated `README.md` to reflect the changes to `NewHTTPErrorResponse` and provide an example of how to use it with wrapped errors.
- Added new test cases to `replier_test.go` to test the new functionality.

## Checklist
- [X] Updated documentation (i.e., `README.md`)
- [X] Updated tests for added feature
- [] Created pre-release(s) - `X`

