### PR TITLE
[REPLY-X] Refactor `ErrorManifest` to use errors instead of strings

### DIFF
--- a/examples/example_simple_api.go
+++ b/examples/example_simple_api.go
@@ -180,11 +180,23 @@ type user struct {
 	Name string `json:"name"`
 }
 
+// handle errors
+var (
+	// errExample404 is an example 404 error
+	errExample404 = errors.New("example-404-error")
+	// errExampleDobValidation is an example dob validation error
+	errExampleDobValidation = errors.New("example-dob-validation-error")
+	// errExampleNameValidation is an example name validation error
+	errExampleNameValidation = errors.New("example-name-validation-error")
+	// errExampleMissing is an example missing error
+	errExampleMissing = errors.New("example-missing-error")
+)
+
 // Example implementation of Error Manifest
 var baseManifest []reply.ErrorManifest = []reply.ErrorManifest{
-	{"example-404-error": reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
-	{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
-	{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
+	{errExample404: reply.ErrorManifestItem{Title: "resource not found", StatusCode: http.StatusNotFound}},
+	{errExampleNameValidation: reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
+	{errExampleDobValidation: reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
 }
 
 // Replier with default Transition Object & Transition Object Error
@@ -202,7 +214,7 @@ var replierWithCustomTransitionObjs *reply.Replier = reply.NewReplier(baseManife
 func simpleUsersAPINotFoundWithCustomTransitionObjsHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Do something with a server
-	serverErr := errors.New("example-404-error")
+	serverErr := errExample404
 
 	_ = replierWithCustomTransitionObjs.NewHTTPResponse(&reply.NewResponseRequest{
 		Writer: w,
@@ -213,7 +225,7 @@ func simpleUsersAPINotFoundWithCustomTransitionObjsHandler(w http.ResponseWriter
 func simpleUsersAPINotFoundHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Do something with a server
-	serverErr := errors.New("example-404-error")
+	serverErr := errExample404
 
 	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
 		Writer: w,
@@ -224,7 +236,7 @@ func simpleUsersAPINotFoundHandler(w http.ResponseWriter, r *http.Request) {
 func simpleUsersAPIMultiErrorHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Do something with a server
-	serverErrs := []error{errors.New("example-dob-validation-error"), errors.New("example-name-validation-error")}
+	serverErrs := []error{errExampleDobValidation, errExampleNameValidation}
 
 	_ = replier.NewHTTPResponse(&reply.NewResponseRequest{
 		Writer: w,
@@ -286,7 +298,7 @@ func simpleAPIDefaultResponseHandler(w http.ResponseWriter, r *http.Request) {
 func simpleUsersAPINotFoundCustomReplierHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Do something with a server
-	serverErr := errors.New("example-404-error")
+	serverErr := errExample404
 
 	replierWithCustomTransitionObj.NewHTTPResponse(&reply.NewResponseRequest{
 		Writer: w,
@@ -300,7 +312,7 @@ func simpleUsersAPINotFoundCustomReplierHandler(w http.ResponseWriter, r *http.R
 func simpleUsersAPIMultiErrorUsingAideWithCustomErrorHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Do something with a server
-	serverErrs := []error{errors.New("example-dob-validation-error"), errors.New("example-name-validation-error")}
+	serverErrs := []error{errExampleDobValidation, errExampleNameValidation}
 
 	_ = replierWithCustomTransitionObjError.NewHTTPMultiErrorResponse(w, serverErrs)
 }
@@ -308,7 +320,7 @@ func simpleUsersAPIMultiErrorUsingAideWithCustomErrorHandler(w http.ResponseWrit
 func simpleUsersAPIMultiErrorUsingAideHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Do something with a server
-	serverErrs := []error{errors.New("example-dob-validation-error"), errors.New("example-name-validation-error")}
+	serverErrs := []error{errExampleDobValidation, errExampleNameValidation}
 
 	_ = replier.NewHTTPMultiErrorResponse(w, serverErrs)
 }
@@ -316,7 +328,7 @@ func simpleUsersAPIMultiErrorUsingAideHandler(w http.ResponseWriter, r *http.Req
 func simpleUsersAPINotFoundUsingAideHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Do something with a server
-	serverErr := errors.New("example-404-error")
+	serverErr := errExample404
 
 	_ = replier.NewHTTPErrorResponse(w, serverErr)
 }
@@ -364,7 +376,7 @@ func simpleAPIDefaultResponseUsingAideHandler(w http.ResponseWriter, r *http.Req
 func simpleUsersAPINotFoundCustomReplierUsingAideHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Do something with a server
-	serverErr := errors.New("example-404-error")
+	serverErr := errExample404
 
 	replierWithCustomTransitionObj.NewHTTPErrorResponse(w, serverErr)
 }

--- a/model.go
+++ b/model.go
@@ -48,9 +48,9 @@ type ErrorManifestItem struct {
 	Meta interface{}
 }
 
-// ErrorManifest holds error reference (string) with its corresponding
+// ErrorManifest holds error  with its corresponding
 // manifest item (message & status code) which it returned in the response
-type ErrorManifest map[string]ErrorManifestItem
+type ErrorManifest map[error]ErrorManifestItem
 
 // defaultReplyTransferObjectError holds attributes often used to give additional
 // context when unexpected behaviour occurs

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,13 @@
 # Reply Release Notes
 
+## [v2.0.0](https://github.com/ooaklee/reply/releases/tag/v2.0.0)
+2025-07-15
+
+* Updated `ErrorManifest` to use `error` as the key instead of `string`
+* Updated `replier.go` to reflect the changes to `ErrorManifest` and use `errors.Is` for error matching
+* Updated `README.md` to reflect the changes
+* Reflected changes in `examples/example_simple_api.go` and provide examples of how to use it with errors
+
 ## [v1.1.0](https://github.com/ooaklee/reply/releases/tag/v1.1.0)
 2025-07-13
 

--- a/replier_test.go
+++ b/replier_test.go
@@ -1589,6 +1589,18 @@ func TestReplier_NewHTTPBlankResponseAide(t *testing.T) {
 	}
 }
 
+// define application errors
+var (
+	// errExample404 is an example 404 error
+	errExample404 = errors.New("example-404-error")
+	// errExampleDobValidation is an example dob validation error
+	errExampleDobValidation = errors.New("example-dob-validation-error")
+	// errExampleNameValidation is an example name validation error
+	errExampleNameValidation = errors.New("example-name-validation-error")
+	// errExampleMissing is an example missing error
+	errExampleMissing = errors.New("example-missing-error")
+)
+
 // stringWithNewLine appends new line to passed string
 func stringWithNewLine(s string) string {
 	return fmt.Sprintf("%s\n", s)
@@ -1612,39 +1624,35 @@ func getEmptyErrorManifest() []reply.ErrorManifest {
 // getDefaultErrorManifest returns the default manifest
 func getDefaultErrorManifest() []reply.ErrorManifest {
 	return []reply.ErrorManifest{
-		{"example-404-error": reply.ErrorManifestItem{Title: "Resource Not Found", StatusCode: http.StatusNotFound}},
-		{"example-dob-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
-		{"example-name-validation-error": reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
+		{errExample404: reply.ErrorManifestItem{Title: "Resource Not Found", StatusCode: http.StatusNotFound}},
+		{errExampleDobValidation: reply.ErrorManifestItem{Title: "Validation Error", Detail: "Check your DoB, and try again.", Code: "100YT", StatusCode: http.StatusBadRequest}},
+		{errExampleNameValidation: reply.ErrorManifestItem{Title: "Validation Error", Detail: "The name provided does not meet validation requirements", StatusCode: http.StatusBadRequest, About: "www.example.com/reply/validation/1011", Code: "1011"}},
 	}
 }
 
 // getMultiErrors returns example errors
 func getMultiErrors() []error {
 	return []error{
-		errors.New("example-dob-validation-error"),
-		errors.New("example-name-validation-error"),
+		errExampleDobValidation,
+		errExampleNameValidation,
 	}
 }
 
 // getWrappedErrors returns wrapped errors
 func getWrappedErrors() error {
-
-	err := errors.New("example-name-validation-error")
-	errTwo := errors.New("example-dob-validation-error")
-
-	return errors.Join(err, errTwo)
+	return errors.Join(errExampleNameValidation, errExampleDobValidation)
 
 }
 
 // getMultiErrorsWithMissingErr returns example errors with one error
 // that does not exist in manifest
 func getMultiErrorsWithMissingErr() []error {
-	return append(getMultiErrors(), errors.New("example-missing-error"))
+	return append(getMultiErrors(), errExampleMissing)
 }
 
 // getExampleErrorOne returns example error (1)
 func getExampleErrorOne() error {
-	return errors.New("example-404-error")
+	return errExample404
 }
 
 // getBlankResponseBody returns default blank response body


### PR DESCRIPTION
## What has been done:
- Updated `ErrorManifest` to use `error` as the key instead of `string`
- Updated `README.md` to reflect the changes to `ErrorManifest` and provide examples of how to use it with errors
- Updated `examples/example_simple_api.go` to reflect the changes to `ErrorManifest` and provide examples of how to use it with errors
- Updated `replier.go` to reflect the changes to `ErrorManifest` and use `errors.Is` for error matching
- Updated `replier_test.go` to reflect the changes to `ErrorManifest` and use errors instead of strings


## Checklist
- [X] Updated documentation (i.e., `README.md`)
- [X] Updated tests for added feature
- [X] Created pre-release(s) - `v2.0.0`

## How to test:
- Run `go test -v ./...`
